### PR TITLE
erlang 19.1 standard on singular atoms

### DIFF
--- a/lib/grpc/logger.ex
+++ b/lib/grpc/logger.ex
@@ -32,7 +32,7 @@ defmodule GRPC.Logger.Server do
     status = elem(result, 0)
 
     Logger.log(level, fn ->
-      diff = System.convert_time_unit(stop - start, :native, :micro_seconds)
+      diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
       ["Response ", inspect(status), " in ", formatted_diff(diff)]
     end)
@@ -76,7 +76,7 @@ defmodule GRPC.Logger.Client do
       status = elem(result, 0)
 
       Logger.log(level, fn ->
-        diff = System.convert_time_unit(stop - start, :native, :micro_seconds)
+        diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
         ["Got ", inspect(status), " in ", GRPC.Logger.Server.formatted_diff(diff)]
       end)


### PR DESCRIPTION
`warning: deprecated time unit: :micro_seconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer
  (grpc) lib/grpc/logger.ex:35: anonymous fn/3 in GRPC.Logger.Server.call/4
  (logger) lib/logger.ex:867: Logger.normalize_message/2
  (logger) lib/logger.ex:690: Logger.__do_log__/3
  (grpc) lib/grpc/logger.ex:34: GRPC.Logger.Server.call/4`

