### PR TITLE
Update typespec to satisfy dialyzer

### DIFF
--- a/lib/grpc/client/stream.ex
+++ b/lib/grpc/client/stream.ex
@@ -24,8 +24,8 @@ defmodule GRPC.Client.Stream do
           rpc: tuple,
           payload: stream_payload,
           path: String.t(),
-          marshal: marshal,
-          unmarshal: unmarshal,
+          marshal: marshal | nil,
+          unmarshal: unmarshal | nil,
           server_stream: boolean,
           canceled: boolean,
           __interface__: map


### PR DESCRIPTION
Since marshal and unmarshal is not yet set when calling `GRPC.Stub.call/5`, this typespec will be broken https://github.com/tony612/grpc-elixir/blob/master/lib/grpc/stub.ex#L190

Otherwise dialyzer will warn that the call made [here](https://github.com/tony612/grpc-elixir/blob/master/lib/grpc/stub.ex#L75) breaks the contract