### PR TITLE
Use :microsecond, :second time units.

### DIFF
--- a/lib/grpc/logger.ex
+++ b/lib/grpc/logger.ex
@@ -32,7 +32,7 @@ defmodule GRPC.Logger.Server do
     status = elem(result, 0)
 
     Logger.log(level, fn ->
-      diff = System.convert_time_unit(stop - start, :native, :micro_seconds)
+      diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
       ["Response ", inspect(status), " in ", formatted_diff(diff)]
     end)
@@ -76,7 +76,7 @@ defmodule GRPC.Logger.Client do
       status = elem(result, 0)
 
       Logger.log(level, fn ->
-        diff = System.convert_time_unit(stop - start, :native, :micro_seconds)
+        diff = System.convert_time_unit(stop - start, :native, :microsecond)
 
         ["Got ", inspect(status), " in ", GRPC.Logger.Server.formatted_diff(diff)]
       end)

--- a/lib/grpc/time_utils.ex
+++ b/lib/grpc/time_utils.ex
@@ -7,8 +7,8 @@ defmodule GRPC.TimeUtils do
   ## Examples
 
       iex> from = DateTime.utc_now
-      iex> us = DateTime.to_unix(from, :microseconds)
-      iex> datetime = DateTime.from_unix!(us + 5005, :microseconds)
+      iex> us = DateTime.to_unix(from, :microsecond)
+      iex> datetime = DateTime.from_unix!(us + 5005, :microsecond)
       iex> Float.round(GRPC.TimeUtils.to_relative(datetime, from), 3)
       5.005
   """
@@ -19,6 +19,6 @@ defmodule GRPC.TimeUtils do
   end
 
   defp datetime_to_milliseconds(datetime) do
-    DateTime.to_unix(datetime, :seconds) * 1000 + elem(datetime.microsecond, 0) * 0.001
+    DateTime.to_unix(datetime, :second) * 1000 + elem(datetime.microsecond, 0) * 0.001
   end
 end


### PR DESCRIPTION
Since Elixir 1.8.0 and Erlang/OTP 19.1 the plural and underscore time units `:seconds`, `:micro_seconds` have been deprecated and prints a warning log when used. 

    warning: deprecated time unit: :micro_seconds. A time unit should be :second, :millisecond, :microsecond, :nanosecond, or a positive integer

Elixir release: [v1.8.0](https://github.com/elixir-lang/elixir/releases/tag/v1.8.0)