### PR TITLE
Return already started pid when starting server

### DIFF
--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -16,7 +16,14 @@ defmodule GRPC.Adapter.Cowboy do
     start_args = cowboy_start_args(endpoint, servers, port, opts)
     start_func = if opts[:cred], do: :start_tls, else: :start_clear
 
-    {:ok, pid} = apply(:cowboy, start_func, start_args)
+    {:ok, pid} =
+      case apply(:cowboy, start_func, start_args) do
+        {:ok, pid} ->
+          {:ok, pid}
+
+        {:error, {:already_started, pid}} ->
+          {:ok, pid}
+      end
 
     port = :ranch.get_port(servers_name(endpoint, servers))
     {:ok, pid, port}

--- a/test/grpc/server_test.exs
+++ b/test/grpc/server_test.exs
@@ -9,6 +9,12 @@ defmodule GRPC.ServerTest do
     use GRPC.Server, service: Greeter.Service
   end
 
+  test "start/2 works" do
+    {:ok, pid, port} = GRPC.Server.start(Greeter.Server, 50053)
+
+    assert {:ok, ^pid, ^port} = GRPC.Server.start(Greeter.Server, 50053)
+  end
+
   test "stop/2 works" do
     assert {nil, %{"hello" => GRPC.ServerTest.Greeter.Server}} =
              GRPC.Server.stop(Greeter.Server, adapter: GRPC.Test.ServerAdapter)


### PR DESCRIPTION
I came across this when using elixir-grpc in my tests. Instead of bombing out when the server is already started, return the running pid to remove that potential error.

Thanks for making this library.