### PR TITLE
Revert "Return already started pid when starting server (#101)"

### DIFF
--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -16,14 +16,7 @@ defmodule GRPC.Adapter.Cowboy do
     start_args = cowboy_start_args(endpoint, servers, port, opts)
     start_func = if opts[:cred], do: :start_tls, else: :start_clear
 
-    {:ok, pid} =
-      case apply(:cowboy, start_func, start_args) do
-        {:ok, pid} ->
-          {:ok, pid}
-
-        {:error, {:already_started, pid}} ->
-          {:ok, pid}
-      end
+    {:ok, pid} = apply(:cowboy, start_func, start_args)
 
     port = :ranch.get_port(servers_name(endpoint, servers))
     {:ok, pid, port}

--- a/test/grpc/server_test.exs
+++ b/test/grpc/server_test.exs
@@ -9,12 +9,6 @@ defmodule GRPC.ServerTest do
     use GRPC.Server, service: Greeter.Service
   end
 
-  test "start/2 works" do
-    {:ok, pid, port} = GRPC.Server.start(Greeter.Server, 50053)
-
-    assert {:ok, ^pid, ^port} = GRPC.Server.start(Greeter.Server, 50053)
-  end
-
   test "stop/2 works" do
     assert {nil, %{"hello" => GRPC.ServerTest.Greeter.Server}} =
              GRPC.Server.stop(Greeter.Server, adapter: GRPC.Test.ServerAdapter)


### PR DESCRIPTION
This reverts commit be4ed8cbe2ef1a284cade96a50b263f12b28c588.

I incorrectly assumed that the two cases `{:ok, pid}` and `{:error, {:already_started, pid}}` were the only ones that could occur when starting the server. 

An error term other than those two could be returned if 
- a [bad tls config is passed](https://github.com/ninenines/ranch/blob/master/src/ranch.erl#L81)
- address is in use `eaddrinuse`
- or other error terms returned from cowboy and ranch.