### PR TITLE
Remove get_stacktrace

### DIFF
--- a/src/grpc_stream_h.erl
+++ b/src/grpc_stream_h.erl
@@ -213,22 +213,8 @@ report_crash(Ref, StreamID, Pid, Reason, Stacktrace) ->
 %% @todo Better spec.
 -spec request_process(_, _, _) -> _.
 request_process(Req, Env, Middlewares) ->
-	OTP = erlang:system_info(otp_release),
-	try
-		execute(Req, Env, Middlewares)
-	catch
-		exit:Reason ->
-			Stacktrace = erlang:get_stacktrace(),
-			erlang:raise(exit, {Reason, Stacktrace}, Stacktrace);
-		%% OTP 19 does not propagate any exception stacktraces,
-		%% we therefore add it for every class of exception.
-		_:Reason when OTP =:= "19" ->
-			Stacktrace = erlang:get_stacktrace(),
-			erlang:raise(exit, {Reason, Stacktrace}, Stacktrace);
-		%% @todo I don't think this clause is necessary.
-		Class:Reason ->
-			erlang:raise(Class, Reason, erlang:get_stacktrace())
-	end.
+  %% no need for special exception handling from OTP 21.
+	execute(Req, Env, Middlewares).
 
 %% @todo
 %-spec execute(cowboy_req:req(), #state{}, cowboy_middleware:env(), [module()])


### PR DESCRIPTION
Special exception handling can be removed, there is no need to separate OTP 19 stacktrace handling.
The new try/catch stacktrace handling mechanism was introduced in OTP 21, making the get_stacktrace function deprecated.
Safe to merge, the current solution is not using the new feature of OTP 21, and OTP 19 is not supported any more.