### PR TITLE
Default read timeout is :infinity

### DIFF
--- a/lib/grpc/adapter/cowboy/handler.ex
+++ b/lib/grpc/adapter/cowboy/handler.ex
@@ -401,7 +401,7 @@ defmodule GRPC.Adapter.Cowboy.Handler do
   defp timeout_left_opt(timer, opts \\ %{}) do
     case timer do
       nil ->
-        opts
+        Map.put(opts, :timeout, :infinity)
 
       timer ->
         case Process.read_timer(timer) do


### PR DESCRIPTION
Potential fix for https://github.com/elixir-grpc/grpc/issues/141