### PR TITLE
shut down gun process when it is not used anymore

### DIFF
--- a/lib/grpc/adapter/gun.ex
+++ b/lib/grpc/adapter/gun.ex
@@ -62,9 +62,11 @@ defmodule GRPC.Adapter.Gun do
         {:ok, Map.put(channel, :adapter_payload, %{conn_pid: conn_pid})}
 
       {:ok, proto} ->
+        :gun.shutdown(conn_pid)
         {:error, "Error when opening connection: protocol #{proto} is not http2"}
 
       {:error, reason} ->
+        :gun.shutdown(conn_pid)
         {:error, "Error when opening connection: #{inspect(reason)}"}
     end
   end


### PR DESCRIPTION
Right now :gun process is not returned to the caller and also not getting shutdown when connection errors, this leads to orphan process and potential memory leak. The gun process will also keep attempting to reconnect but even it if it did reconnect there is no way to actually use it.

This PR shutdown the process when it is not used.