### PR TITLE
Don't format parens around `field`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -2,8 +2,8 @@
 [
   inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}", "examples/*/{config,lib,priv}/*.ex"],
   import_deps: [:protobuf],
-  locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2],
+  locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2, field: 2, field: 3],
   export: [
-    locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2]
+    locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2, field: 2, field, 3]
   ]
 ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,6 +4,6 @@
   import_deps: [:protobuf],
   locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2, field: 2, field: 3],
   export: [
-    locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2, field: 2, field, 3]
+    locals_without_parens: [rpc: 3, intercept: 1, intercept: 2, run: 1, run: 2, field: 2, field: 3]
   ]
 ]


### PR DESCRIPTION
Our project is importing elixir-grpc, and all DSL functions are making it through the formatter except for `field`. This PR adds `field` to the formatter DSL whitelist.