### PR TITLE
feature: introduce get cert

### DIFF
--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -143,6 +143,10 @@ defmodule GRPC.Adapter.Cowboy do
     Handler.get_peer(pid)
   end
 
+  def get_cert(%{pid: pid}) do
+    Handler.get_cert(pid)
+  end
+
   def set_compressor(%{pid: pid}, compressor) do
     Handler.set_compressor(pid, compressor)
   end

--- a/lib/grpc/adapter/cowboy/handler.ex
+++ b/lib/grpc/adapter/cowboy/handler.ex
@@ -150,6 +150,10 @@ defmodule GRPC.Adapter.Cowboy.Handler do
     sync_call(pid, :get_peer)
   end
 
+  def get_cert(pid) do
+    sync_call(pid, :get_cert)
+  end
+
   defp sync_call(pid, key) do
     ref = make_ref()
     send(pid, {key, ref, self()})
@@ -215,6 +219,12 @@ defmodule GRPC.Adapter.Cowboy.Handler do
 
   def info({:get_peer, ref, pid}, req, state) do
     peer = :cowboy_req.peer(req)
+    send(pid, {ref, peer})
+    {:ok, req, state}
+  end
+
+  def info({:get_cert, ref, pid}, req, state) do
+    peer = :cowboy_req.cert(req)
     send(pid, {ref, peer})
     {:ok, req, state}
   end

--- a/test/grpc/integration/server_test.exs
+++ b/test/grpc/integration/server_test.exs
@@ -23,6 +23,16 @@ defmodule GRPC.Integration.ServerTest do
       Helloworld.HelloReply.new(message: "Hello, #{name}")
     end
 
+    def say_hello(%{name: "get cert"}, stream) do
+      case stream.adapter.get_cert(stream.payload) do
+        :undefined ->
+          Helloworld.HelloReply.new(message: "Hello, unauthenticated")
+
+        _ ->
+          Helloworld.HelloReply.new(message: "Hello, authenticated")
+      end
+    end
+
     def say_hello(req, _stream) do
       Helloworld.HelloReply.new(message: "Hello, #{req.name}")
     end
@@ -192,6 +202,16 @@ defmodule GRPC.Integration.ServerTest do
       req = Helloworld.HelloRequest.new(name: "get peer")
       {:ok, reply} = channel |> Helloworld.Greeter.Stub.say_hello(req)
       assert reply.message == "Hello, 127.0.0.1"
+    end)
+  end
+
+  test "get cert returns correct client certificate when not present" do
+    run_server([HelloServer], fn port ->
+      {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
+
+      req = Helloworld.HelloRequest.new(name: "get cert")
+      {:ok, reply} = channel |> Helloworld.Greeter.Stub.say_hello(req)
+      assert reply.message == "Hello, unauthenticated"
     end)
   end
 end


### PR DESCRIPTION
First of all, thanks for this code! Awesome work.

This is similar to #119, but for [`:cowboy_req.cert/1`](https://ninenines.eu/docs/en/cowboy/2.6/manual/cowboy_req.cert/)

The motivation behind came because I'm implementing a IoT system and wanted to use Mutual TLS to identify the device, using the Common Name for that.

For that, I needed access to the client certificate so I could fetch the CN and finally uniquely identify the device, but gRPC didn't gave me access to the client certificate, so I ended up implementing this PR.

I still need to test that it returns the client certificate, but that would require me generating client keys and stuff, and it is already pretty late here, so I'll leave for another day.

Wanted to create the PR to check if you are interested in this.

Cheers