### PR TITLE
feat: Use location: :keep to make error messages better.

### DIFF
--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -41,7 +41,7 @@ defmodule GRPC.Server do
   @type rpc :: (GRPC.Server.rpc_req(), Stream.t() -> rpc_return)
 
   defmacro __using__(opts) do
-    quote bind_quoted: [opts: opts] do
+    quote bind_quoted: [opts: opts], location: :keep do
       service_mod = opts[:service]
       service_name = service_mod.__meta__(:name)
       codecs = opts[:codecs] || [GRPC.Codec.Proto]


### PR DESCRIPTION
When implementing a server, error messages from the implementation
become a bit hard to parse with this missing because it gets offset by
the total size of the `__using__` macro.