### PR TITLE
Add :reuseaddr transport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ An Elixir implementation of [gRPC](http://www.grpc.io/).
 
 **NOTICE: Erlang/OTP needs >= 20.3.2**
 
+**NOTICE: grpc_gun**
+
+Now `{:gun, "~> 2.0.0", hex: :grpc_gun}` is used in mix.exs because grpc depnds on Gun 2.0,
+but its stable version is not released. So I published a [2.0 version on hex](https://hex.pm/packages/grpc_gun)
+with a different name. So if you have other dependencies who depends on Gun, you need to use
+override: `{:gun, "~> 2.0.0", hex: :grpc_gun, override: true}`. Let's wait for this issue
+https://github.com/ninenines/gun/issues/229.
+
 ## Installation
 
 The package can be installed as:

--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -183,6 +183,7 @@ defmodule GRPC.Adapter.Cowboy do
   defp socket_opts(port, opts) do
     socket_opts = [port: port]
     socket_opts = if opts[:ip], do: [{:ip, opts[:ip]} | socket_opts], else: socket_opts
+    socket_opts = if opts[:reuseaddr], do [{:reuseaddr, true} | socket_opts], else: socket_opts
 
     if opts[:cred] do
       opts[:cred].ssl ++

--- a/lib/grpc/adapter/cowboy/handler_error.ex
+++ b/lib/grpc/adapter/cowboy/handler_error.ex
@@ -1,0 +1,20 @@
+defmodule GRPC.Adapter.Cowboy.HandlerError do
+  defexception [:req, :kind, :reason, :stack]
+
+  def new(req, %{__exception__: _} = e, stack \\ []) do
+    exception(req: req, kind: :error, reason: e, stack: stack)
+  end
+
+  def exception(params) when is_list(params) do
+    struct(__MODULE__, params)
+  end
+
+  def message(%{req: req, kind: kind, reason: reason, stack: stack}) do
+    path = :cowboy_req.path(req)
+    "While handling #{path}:\n  " <> Exception.format_banner(kind, reason, stack)
+  end
+
+  def reraise(%__MODULE__{} = error) do
+    :erlang.raise(:error, error, error.stack)
+  end
+end

--- a/lib/grpc/adapter/gun.ex
+++ b/lib/grpc/adapter/gun.ex
@@ -62,9 +62,11 @@ defmodule GRPC.Adapter.Gun do
         {:ok, Map.put(channel, :adapter_payload, %{conn_pid: conn_pid})}
 
       {:ok, proto} ->
+        :gun.shutdown(conn_pid)
         {:error, "Error when opening connection: protocol #{proto} is not http2"}
 
       {:error, reason} ->
+        :gun.shutdown(conn_pid)
         {:error, "Error when opening connection: #{inspect(reason)}"}
     end
   end

--- a/test/support/integration_test_case.ex
+++ b/test/support/integration_test_case.ex
@@ -50,4 +50,34 @@ defmodule GRPC.Integration.TestCase do
         result
     end
   end
+
+  defmodule ErrorHandler do
+    @behaviour :gen_event
+
+    def init(test_case_pid), do: {:ok, %{test_case_pid: test_case_pid}}
+
+    def handle_call(_, state) do
+      {:ok, :ok, state}
+    end
+
+    def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
+        when is_list(message) do
+      error_info = message[:error_info]
+      send(state.test_case_pid, {:error_report, error_info})
+
+      {:ok, state}
+    end
+
+    def handle_event({_level, _gl, _event}, state) do
+      {:ok, state}
+    end
+  end
+
+  def attach_error_handler do
+    :error_logger.add_report_handler(ErrorHandler, self())
+
+    on_exit(fn ->
+      :error_logger.delete_report_handler(ErrorHandler)
+    end)
+  end
 end


### PR DESCRIPTION
There is a long standing issue breaking tests where a gRPC mock server will listen on a port without REUSEADDR. The connections to the server may be left in the TIME_WAIT state and prevent a subsequent server from spawning and listening on the port.