### PR TITLE
Fix and update GitHub Actions config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,14 @@ jobs:
   check_format:
     runs-on: ubuntu-latest
     name: Check format
-    container:
-      image: elixir:1.9-slim
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-elixir@v1
+        with:
+          otp-version: '23.2.4'
+          elixir-version: '1.11.3'
+      - name: Install dependencies
+        run: mix deps.get
       - name: Check format
         run: mix format --check-formatted
 
@@ -29,39 +28,32 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: [20.x, 21.x, 22.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x]
-        exclude:
-          - otp: 20.x
-            elixir: 1.10.x
+        otp: [21.x, 22.x, 23.x]
+        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x]
     needs: check_format
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/checkout@v2
+    - uses: erlef/setup-elixir@v1
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-    - name: Run Tests
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Run tests
       run: mix test
 
   interop-tests:
     runs-on: ubuntu-latest
     name: Interop tests
-    container:
-      image: elixir:1.9-slim
     needs: check_format
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
+    - uses: actions/checkout@v2
+    - uses: erlef/setup-elixir@v1
+      with:
+        otp-version: '23.2.4'
+        elixir-version: '1.11.3'
+    - name: Install dependencies
+      run: mix deps.get
       working-directory: ./interop
     - name: Run interop tests
       run: mix run script/run.exs
@@ -71,15 +63,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Check release
     needs: check_format
-    container:
-      image: elixir:1.9-slim
     steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        run: |
-          mix local.rebar --force
-          mix local.hex --force
-          mix deps.get
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-elixir@v1
+        with:
+          otp-version: '23.2.4'
+          elixir-version: '1.11.3'
+      - name: Install dependencies
+        run: mix deps.get
       - name: Build hex
         run: mix hex.build
       - name: Generate docs

--- a/.github/workflows/cron_ci.yml
+++ b/.github/workflows/cron_ci.yml
@@ -8,15 +8,14 @@ jobs:
   interop-tests:
     runs-on: ubuntu-latest
     name: Interop tests
-    container:
-      image: elixir:1.9
     steps:
-    - uses: actions/checkout@v1
-    - name: Install Dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
+    - uses: actions/checkout@v2
+    - uses: erlef/setup-elixir@v1
+      with:
+        otp-version: '23.2.4'
+        elixir-version: '1.11.3'
+    - name: Install dependencies
+      run: mix deps.get
       working-directory: ./interop
     - name: Run Cron CI
       run: make ci-cron


### PR DESCRIPTION
Some GitHub Actions are failing on `master`, so this PR:

* updates `actions/checkout` to v2 (which is [faster](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v2-beta))
* switches to `erlef/setup-elixir` since [`actions/setup-elixir` is archived](https://github.com/actions/setup-elixir#setup-elixir),
* unifies Elixir setup by removing `container` uses,
* adds OTP 23 and Elixir 1.11 to the test matrix,
* drops OTP 20 from the test matrix (Elixir 1.10 doesn't support it and it's 4 years old),
* removes unnecessary steps like installing Hex/Rebar.

Let me know what you think :raised_hands: 