### PR TITLE
Provide a mechanism to capture exceptions during request handling

### DIFF
--- a/lib/grpc/endpoint.ex
+++ b/lib/grpc/endpoint.ex
@@ -9,6 +9,7 @@ defmodule GRPC.Endpoint do
 
         intercept GRPC.Logger.Server, level: :info
         intercept Other.Interceptor
+        exception_sink My.Exception.Sink
         run HelloServer, interceptors: [HelloHaltInterceptor]
         run FeatureServer
       end
@@ -22,10 +23,11 @@ defmodule GRPC.Endpoint do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      import GRPC.Endpoint, only: [intercept: 1, intercept: 2, run: 1, run: 2]
+      import GRPC.Endpoint, only: [intercept: 1, intercept: 2, exception_sink: 1, exception_sink: 2, run: 1, run: 2]
 
       Module.register_attribute(__MODULE__, :interceptors, accumulate: true)
       Module.register_attribute(__MODULE__, :servers, accumulate: true)
+      Module.register_attribute(__MODULE__, :exception_sinks, accumulate: true)
       @before_compile GRPC.Endpoint
     end
   end
@@ -38,6 +40,12 @@ defmodule GRPC.Endpoint do
       |> Enum.reverse()
       |> init_interceptors()
 
+    exception_sinks =
+      Module.get_attribute(env.module, :exception_sinks)
+      |> Macro.escape()
+      |> Enum.reverse()
+      |> init_exception_sinks()
+
     servers = Module.get_attribute(env.module, :servers)
     servers = Enum.map(servers, fn {ss, opts} -> {ss, parse_run_opts(opts, %{})} end)
     server_interceptors = server_interceptors(servers, %{})
@@ -47,6 +55,7 @@ defmodule GRPC.Endpoint do
       def __meta__(:interceptors), do: unquote(interceptors)
       def __meta__(:servers), do: unquote(servers)
       def __meta__(:server_interceptors), do: unquote(Macro.escape(server_interceptors))
+      def __meta__(:exception_sinks), do: unquote(exception_sinks)
     end
   end
 
@@ -75,6 +84,28 @@ defmodule GRPC.Endpoint do
   defmacro run(servers, opts \\ []) do
     quote do
       @servers {unquote(servers), unquote(opts)}
+    end
+  end
+
+  @doc """
+  ## Options
+
+    * `:exception_sinks` - custom exception sinks for capturing exceptions for further processing/logging
+  """
+  defmacro exception_sink(name) do
+    quote do
+      @exception_sinks unquote(name)
+    end
+  end
+
+  @doc """
+  ## Options
+
+  `opts` keyword will be passed to ExceptionSink's init/1
+  """
+  defmacro exception_sink(name, opts) do
+    quote do
+      @exception_sinks {unquote(name), unquote(opts)}
     end
   end
 
@@ -117,6 +148,16 @@ defmodule GRPC.Endpoint do
 
       interceptor ->
         {interceptor, interceptor.init([])}
+    end)
+  end
+
+  defp init_exception_sinks(exception_sinks) do
+    Enum.map(exception_sinks, fn
+      {exception_sink, opts} ->
+        {exception_sink, exception_sink.init(opts)}
+
+      exception_sink ->
+        {exception_sink, exception_sink.init([])}
     end)
   end
 end

--- a/lib/grpc/exception_sink.ex
+++ b/lib/grpc/exception_sink.ex
@@ -1,0 +1,12 @@
+defmodule GRPC.ExceptionSink do
+  @moduledoc """
+  Exception sink for the server side. See `GRPC.Endpoint`.
+  """
+
+  @type options :: any
+  @type error :: any
+  @type stack_trace :: any
+
+  @callback init(options) :: options
+  @callback error(error, stack_trace) :: nil
+end

--- a/test/grpc/endpoint_test.exs
+++ b/test/grpc/endpoint_test.exs
@@ -17,6 +17,17 @@ defmodule GRPC.EndpointTest do
     def init(opts), do: opts
   end
 
+  defmodule ExceptionSink1 do
+    def init(_), do: nil
+    def error(_), do: nil
+  end
+
+  defmodule ExceptionSink2 do
+    def init(opts), do: opts
+    def error(_), do: nil
+  end
+
+
   defmodule FooEndpoint do
     use GRPC.Endpoint
 
@@ -40,5 +51,18 @@ defmodule GRPC.EndpointTest do
 
     assert %{Server1 => [{Interceptor3, [foo: :bar]}], Server2 => mw, Server3 => mw} ==
              FooEndpoint.__meta__(:server_interceptors)
+  end
+
+  defmodule EndpointWithExceptionSink do
+    use GRPC.Endpoint
+
+    exception_sink ExceptionSink1
+    exception_sink ExceptionSink2, foo: 1
+
+    run ServerThatProducesException
+  end
+
+  test "defining exception sinks works" do
+    assert [{ExceptionSink1, nil}, {ExceptionSink2, [foo: 1]}] == EndpointWithExceptionSink .__meta__(:exception_sinks)
   end
 end


### PR DESCRIPTION
Interceptors are insufficient for capturing errors in the general case
because they execute *after* a request has already been successfully
decoded.

This commit introduces a new concept called an ExceptionSink. It is a
behavior that exposes an `error/2` function.

ExceptionSinks are attached to an Endpoint like this:

```elixir
defmodule EndpointWithExceptionSink do
  use GRPC.Endpoint

  exception_sink ExceptionSink1
  exception_sink ExceptionSink2, foo: 1

  run Server
end
```

An ExceptionSink receives the raised exception and a stack trace,
allowing the developer to process/forward that information to the
observability tool of their choice.

Exceptions that are caught before sending to the exception sinks are
reraised so that the existing behaviour is preserved.