### PR TITLE
Allow RPC handlers to return errors

### DIFF
--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -161,12 +161,16 @@ defmodule GRPC.Server do
          req
        ) do
     last = fn r, s ->
-      reply = apply(server, func_name, [r, s])
+      case apply(server, func_name, [r, s]) do
+        error = {:error, _} ->
+          error
 
-      if res_stream do
-        {:ok, stream}
-      else
-        {:ok, stream, reply}
+        reply ->
+          if res_stream do
+            {:ok, stream}
+          else
+            {:ok, stream, reply}
+          end
       end
     end
 


### PR DESCRIPTION
Having to raise an exception to signal an error is slower (because
exceptions are, well, exceptional), and it also interferes with
exception logging interceptors.  This change allows RPC handler
methods to return {:error, ...} and have the expected thing happen --
which happens to be exactly how interceptors work, as a bonus.