### PR TITLE
feat: implement telemetry interceptor on client side

### DIFF
--- a/examples/helloworld/mix.exs
+++ b/examples/helloworld/mix.exs
@@ -19,6 +19,7 @@ defmodule Helloworld.Mixfile do
     [
       {:grpc, path: "../../"},
       {:protobuf, "~> 0.10"},
+      {:telemetry, "~> 1.0"},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
     ]
   end

--- a/examples/helloworld/mix.lock
+++ b/examples/helloworld/mix.lock
@@ -6,4 +6,5 @@
   "gun": {:hex, :gun, "2.0.0-rc.2", "7c489a32dedccb77b6e82d1f3c5a7dadfbfa004ec14e322cdb5e579c438632d2", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm", "6b9d1eae146410d727140dbf8b404b9631302ecc2066d1d12f22097ad7d254fc"},
   "protobuf": {:hex, :protobuf, "0.10.0", "4e8e3cf64c5be203b329f88bb8b916cb8d00fb3a12b2ac1f545463ae963c869f", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "4ae21a386142357aa3d31ccf5f7d290f03f3fa6f209755f6e87fc2c58c147893"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
 }

--- a/examples/helloworld/priv/client.exs
+++ b/examples/helloworld/priv/client.exs
@@ -16,12 +16,19 @@ prefix = [:grpc, :client, :request]
 
 :telemetry.attach_many(
   "ClientEvent",
-  [prefix ++ [:start], prefix ++ [:stop], prefix ++ [:exception]],
+  [
+    prefix ++ [:start],
+    prefix ++ [:stop],
+    prefix ++ [:exception],
+    prefix ++ [:recv_headers, :start],
+    prefix ++ [:recv_headers, :stop],
+    prefix ++ [:recv_headers, :exception],
+  ],
   &LoggerEvent.handle_event/4,
   %{}
 )
 
-{:ok, channel} = GRPC.Stub.connect("localhost:50051", interceptors: [GRPC.Telemetry.Client])
+{:ok, channel} = GRPC.Stub.connect("localhost:50051")
 
 {:ok, reply} =
   channel |> Helloworld.Greeter.Stub.say_hello(Helloworld.HelloRequest.new(name: "grpc-elixir"))

--- a/examples/helloworld/priv/client.exs
+++ b/examples/helloworld/priv/client.exs
@@ -20,9 +20,7 @@ prefix = [:grpc, :client, :request]
     prefix ++ [:start],
     prefix ++ [:stop],
     prefix ++ [:exception],
-    prefix ++ [:recv_headers, :start],
-    prefix ++ [:recv_headers, :stop],
-    prefix ++ [:recv_headers, :exception],
+    prefix ++ [:recv_headers],
   ],
   &LoggerEvent.handle_event/4,
   %{}

--- a/examples/helloworld/priv/client.exs
+++ b/examples/helloworld/priv/client.exs
@@ -1,4 +1,27 @@
-{:ok, channel} = GRPC.Stub.connect("localhost:50051", interceptors: [GRPC.Logger.Client])
+defmodule LoggerEvent do
+  require Logger
+
+  def handle_event(event, measurements, metadata, config) do
+    Logger.info("""
+    Receive event,
+
+      Event: #{inspect(event)},
+      Measurements: #{inspect(measurements)},
+      Metadata: #{inspect(metadata)}
+    """)
+  end
+end
+
+prefix = [:grpc, :client, :request]
+
+:telemetry.attach_many(
+  "ClientEvent",
+  [prefix ++ [:start], prefix ++ [:stop], prefix ++ [:exception]],
+  &LoggerEvent.handle_event/4,
+  %{}
+)
+
+{:ok, channel} = GRPC.Stub.connect("localhost:50051", interceptors: [GRPC.Telemetry.Client])
 
 {:ok, reply} =
   channel |> Helloworld.Greeter.Stub.say_hello(Helloworld.HelloRequest.new(name: "grpc-elixir"))

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -261,7 +261,11 @@ defmodule GRPC.Stub do
         accepted_compressors: accepted_compressors
     }
 
-    do_call(req_stream, stream, request, opts)
+    metadata = GRPC.Telemetry.metadata_from_stream(stream)
+
+    :telemetry.span([:grpc, :client, :request], metadata, fn ->
+      {do_call(req_stream, stream, request, opts), metadata}
+    end)
   end
 
   defp do_call(
@@ -396,7 +400,11 @@ defmodule GRPC.Stub do
         opts
       end
 
-    interface[:recv].(stream, opts)
+    metadata = GRPC.Telemetry.metadata_from_stream(stream)
+
+    :telemetry.span([:grpc, :client, :request, :recv_headers], metadata, fn ->
+      {interface[:recv].(stream, opts), metadata}
+    end)
   end
 
   @doc false

--- a/lib/grpc/telemetry.ex
+++ b/lib/grpc/telemetry.ex
@@ -1,0 +1,12 @@
+defmodule GRPC.Telemetry do
+
+  def metadata_from_stream(stream) do
+    %{
+      stream: stream,
+      service_name: stream.service_name,
+      method_name: stream.method_name,
+      host: stream.channel.host,
+      port: stream.channel.port
+    }
+  end
+end

--- a/lib/grpc/telemetry/client.ex
+++ b/lib/grpc/telemetry/client.ex
@@ -1,0 +1,36 @@
+defmodule GRPC.Telemetry.Client do
+  @moduledoc """
+  Telemetry interceptor for GRPC client.
+
+  ## Events
+
+  TBD.
+  """
+
+  @behaviour GRPC.ClientInterceptor
+
+  @prefix [:grpc, :client, :request]
+  @default_metadata %{}
+
+  @impl true
+  def init(opts) do
+    # TODO: clarify opts for this interceptor.
+    opts
+  end
+
+  @impl true
+  def call(%{grpc_type: :unary} = stream, req, next, _opts) do
+    # TODO: attach stream information to metadata.
+    metadata = Map.merge(@default_metadata, %{stream: stream})
+
+    :telemetry.span(@prefix, metadata, fn ->
+      reply = next.(stream, req)
+      {reply, %{reply: reply}}
+    end)
+  end
+
+  @impl true
+  def call(stream, req, next, _opts) do
+    next.(stream, req)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule GRPC.Mixfile do
       {:cowboy, "~> 2.9"},
       {:gun, "~> 2.0.0-rc.2"},
       {:cowlib, "~> 2.11"},
+      {:telemetry, "~> 1.0"},
       {:protobuf, "~> 0.10", only: [:dev, :test]},
       {:ex_doc, "~> 0.28", only: :dev},
       {:inch_ex, "~> 2.0", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -15,4 +15,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "protobuf": {:hex, :protobuf, "0.10.0", "4e8e3cf64c5be203b329f88bb8b916cb8d00fb3a12b2ac1f545463ae963c869f", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "4ae21a386142357aa3d31ccf5f7d290f03f3fa6f209755f6e87fc2c58c147893"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
 }


### PR DESCRIPTION
This is a draft PR to add telemetry to the client side. It's just interceptor that call span that capture `next.(stream, req)`. Currently, the interceptor attach `stream` to metadata when span is start, and add `reply` when the span stop. I've modify the helloworld example to show how implement logger with telemetry, its print all event and information of that event. 

<img width="1920" alt="Screen Shot 2565-07-23 at 20 59 08" src="https://user-images.githubusercontent.com/484530/180608291-85832365-ee65-4c9e-8351-2edf450d71c2.png">

Please note that it support only unary operation call. The event metadata can be change during discussion. 🙇 

This is work in progress since it's lack of unit tests.

Updates #229