### PR TITLE
fix: fix dialyzer in GRPC.Server.Supervisor

### DIFF
--- a/lib/grpc/server/supervisor.ex
+++ b/lib/grpc/server/supervisor.ex
@@ -20,6 +20,13 @@ defmodule GRPC.Server.Supervisor do
 
   use Supervisor
 
+  # TODO: remove this type after support Elixir 1.14 exclusively.
+  @type sup_flags() :: %{
+          strategy: Supervisor.strategy(),
+          intensity: non_neg_integer(),
+          period: pos_integer()
+        }
+
   @default_adapter GRPC.Server.Adapters.Cowboy
   require Logger
 
@@ -37,8 +44,8 @@ defmodule GRPC.Server.Supervisor do
   Either `:endpoint` or `:servers` must be present, but not both.
   """
   @spec init(tuple()) :: no_return
-  @spec init(keyword()) :: {:ok, {:supervisor.sup_flags(), [:supervisor.child_spec()]}} | :ignore
-  def init(opts \\ [])
+  @spec init(keyword()) :: {:ok, {sup_flags(), [Supervisor.child_spec()]}} | :ignore
+  def init(opts)
 
   def init(opts) when is_tuple(opts) do
     raise ArgumentError,


### PR DESCRIPTION
Found dialyzer error on master branch:

```
lib/grpc/server/supervisor.ex:39:callback_spec_type_mismatch
The @spec return type does not match the expected return type
for init/1 callback in Supervisor behaviour.

Actual:
@spec init(...) :: 
  {:ok,
   {{:one_for_all, non_neg_integer(), pos_integer()}
    | {:one_for_one, non_neg_integer(), pos_integer()}
    | {:rest_for_one, non_neg_integer(), pos_integer()}
    | {:simple_one_for_one, non_neg_integer(), pos_integer()}
    | %{
        :auto_shutdown => :all_significant | :any_significant | :never,
        :intensity => non_neg_integer(),
        :period => pos_integer(),
        :strategy => :one_for_all | :one_for_one | :rest_for_one | :simple_one_for_one
      },
    [
      {_, {atom(), atom(), :undefined | [any()]}, :permanent | :temporary | :transient,
       :brutal_kill | timeout(), :supervisor | :worker, :dynamic | [atom()]}
      | %{
          :id => _,
          :start => {atom(), atom(), :undefined | [any()]},
          :modules => :dynamic | [atom()],
          :restart => :permanent | :temporary | :transient,
          :shutdown => :brutal_kill | timeout(),
          :significant => boolean(),
          :type => :supervisor | :worker
        }
    ]}}


Expected:
@spec init(...) :: 
  :ignore
  | {:ok,
     {%{
        :intensity => non_neg_integer(),
        :period => pos_integer(),
        :strategy => :one_for_all | :one_for_one | :rest_for_one
      },
      [
        {_, {atom(), atom(), :undefined | [any()]}, :permanent | :temporary | :transient,
         :brutal_kill | timeout(), :supervisor | :worker, :dynamic | [atom()]}
        | %{
            :id => _,
            :start => {atom(), atom(), :undefined | [any()]},
            :modules => :dynamic | [atom()],
            :restart => :permanent | :temporary | :transient,
            :shutdown => :brutal_kill | timeout(),
            :significant => boolean(),
            :type => :supervisor | :worker
          }
      ]}}


________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```

The `sup_flags()` type introduced in Elixir 1.14. So I create a new type in `GRPC.Server.Supervisor` module to support earlier versions.