### PR TITLE
fix: restore deprecated interceptor modules

### DIFF
--- a/lib/grpc/client/interceptor.ex
+++ b/lib/grpc/client/interceptor.ex
@@ -1,3 +1,20 @@
+defmodule GRPC.ClientInterceptor do
+  @moduledoc """
+  Interceptor on client side. See `GRPC.Stub.connect/2`.
+  """
+
+  @moduledoc deprecated: "Use `GRPC.Client.Interceptor` instead"
+
+  alias GRPC.Client.Stream
+
+  @type options :: any()
+  @type req :: struct() | nil
+  @type next :: (Stream.t(), req -> GRPC.Stub.rpc_return())
+
+  @callback init(options) :: options
+  @callback call(stream :: Stream.t(), req, next, options) :: GRPC.Stub.rpc_return()
+end
+
 defmodule GRPC.Client.Interceptor do
   @moduledoc """
   Interceptor on client side. See `GRPC.Stub.connect/2`.

--- a/lib/grpc/server/interceptor.ex
+++ b/lib/grpc/server/interceptor.ex
@@ -1,3 +1,21 @@
+defmodule GRPC.ServerInterceptor do
+  @moduledoc """
+  Interceptor on server side. See `GRPC.Endpoint`.
+  """
+
+  @moduledoc deprecated: "Use `GRPC.Server.Interceptor` instead"
+
+  alias GRPC.Server.Stream
+
+  @type options :: any()
+  @type rpc_return ::
+          {:ok, Stream.t(), struct()} | {:ok, Stream.t()} | {:error, GRPC.RPCError.t()}
+  @type next :: (GRPC.Server.rpc_req(), Stream.t() -> rpc_return())
+
+  @callback init(options) :: options
+  @callback call(GRPC.Server.rpc_req(), stream :: Stream.t(), next, options) :: rpc_return
+end
+
 defmodule GRPC.Server.Interceptor do
   @moduledoc """
   Interceptor on server side. See `GRPC.Endpoint`.


### PR DESCRIPTION
I found the compilation warning in interop tests since PR #289 was merged. Because of GRPC Prometheus didn't change to use the new interceptor module. And it's suddenly breaking changes. So I propose to bring it back but add the deprecated module to it. The rest topic is discussing when to remove it. :)