### PR TITLE
Add support for ranch_tcp opts: ip, ipv6_v6only, inet, inet6

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.3-otp-25
-erlang 25.0.3
+elixir 1.14.1-otp-25
+erlang 25.1.1

--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -224,7 +224,7 @@ defmodule GRPC.Server.Adapters.Cowboy do
 
     # https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_tcp/
     socket_opts =
-      Enum.reduce(opts, socket_opts, fn 
+      Enum.reduce(opts, socket_opts, fn
         {k, v}, acc when k in [:ip, :ipv6_v6only] and not is_nil(v) -> [{k, v} | acc]
         {:net, v}, acc when not is_nil(v) -> [v | acc]
         _, acc -> acc

--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -221,7 +221,22 @@ defmodule GRPC.Server.Adapters.Cowboy do
 
   defp socket_opts(port, opts) do
     socket_opts = [port: port]
-    socket_opts = if opts[:ip], do: [{:ip, opts[:ip]} | socket_opts], else: socket_opts
+
+    # https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_tcp/
+    allowed_ranch_opts = %{
+      ip: {:ip, opts[:ip]},
+      ipv6_v6only: {:ipv6_v6only, opts[:ipv6_v6only]},
+      net: opts[:net]
+    }
+
+    socket_opts =
+      Enum.reduce(allowed_ranch_opts, socket_opts, fn {key, value}, acc ->
+        if opts[key] != nil do
+          [value | acc]
+        else
+          acc
+        end
+      end)
 
     if opts[:cred] do
       opts[:cred].ssl ++

--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -223,7 +223,7 @@ defmodule GRPC.Server.Adapters.Cowboy do
     socket_opts = [port: port]
 
     # https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_tcp/
-    socket_opts = 
+    socket_opts =
       Enum.reduce(opts, socket_opts, fn 
         {k, v}, acc when k in [:ip, :ipv6_v6only] and not is_nil(v) -> [{k, v} | acc]
         {:net, v}, acc when not is_nil(v) -> [v | acc]

--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -223,19 +223,11 @@ defmodule GRPC.Server.Adapters.Cowboy do
     socket_opts = [port: port]
 
     # https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_tcp/
-    allowed_ranch_opts = %{
-      ip: {:ip, opts[:ip]},
-      ipv6_v6only: {:ipv6_v6only, opts[:ipv6_v6only]},
-      net: opts[:net]
-    }
-
-    socket_opts =
-      Enum.reduce(allowed_ranch_opts, socket_opts, fn {key, value}, acc ->
-        if opts[key] != nil do
-          [value | acc]
-        else
-          acc
-        end
+    socket_opts = 
+      Enum.reduce(opts, socket_opts, fn 
+        {k, v}, acc when k in [:ip, :ipv6_v6only] and not is_nil(v) -> [{k, v} | acc]
+        {:net, v}, acc when not is_nil(v) -> [v | acc]
+        _, acc -> acc
       end)
 
     if opts[:cred] do

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule GRPC.Mixfile do
     [
       app: :grpc,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule GRPC.Mixfile do
     [
       app: :grpc,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/grpc/server/adapters/cowboy_test.exs
+++ b/test/grpc/server/adapters/cowboy_test.exs
@@ -1,0 +1,49 @@
+defmodule GRPC.Server.Adapters.CowboyTest do
+  use ExUnit.Case, async: false
+
+  alias GRPC.Server.Adapters.Cowboy
+
+  describe "child_spec/4" do
+    test "produces the correct socket opts for ranch_tcp for inet" do
+      spec =
+        Cowboy.child_spec(:endpoint, [], 8080, [
+          {:foo, :bar},
+          {:ip, {127, 0, 0, 1}},
+          {:ipv6_v6only, false},
+          {:net, :inet},
+          {:baz, :foo}
+        ])
+
+      socket_opts = get_socket_opts_from_child_spec(spec)
+      assert socket_opts == [:inet, {:ipv6_v6only, false}, {:ip, {127, 0, 0, 1}}, {:port, 8080}]
+    end
+
+    test "produces the correct socket opts for ranch_tcp for inet6" do
+      spec =
+        Cowboy.child_spec(:endpoint, [], 8081, [
+          {:foo, :bar},
+          {:ip, {0, 0, 0, 0, 0, 0, 0, 1}},
+          {:ipv6_v6only, true},
+          {:net, :inet6},
+          {:baz, :foo}
+        ])
+
+      socket_opts = get_socket_opts_from_child_spec(spec)
+
+      assert socket_opts == [
+               :inet6,
+               {:ipv6_v6only, true},
+               {:ip, {0, 0, 0, 0, 0, 0, 0, 1}},
+               {:port, 8081}
+             ]
+    end
+  end
+
+  defp get_socket_opts_from_child_spec(spec) do
+    {_Cowboy, _start_link, start_opts} = spec.start
+    [_http, _endpoint, _empty_list, ranch_listener_call] = start_opts
+    {_ranch_listener_sup, _start_link, ranch_listener_opts} = ranch_listener_call
+    [_endpoint, _ranch_tcp, transport_opts, _cowboy_clear, _opts_map] = ranch_listener_opts
+    transport_opts.socket_opts
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/elixir-grpc/grpc/issues/305

It's a bit awkward because `ranch_tcp`'s listen options are all keyword tuples _except_ for `:inet` and `:inet6`, so I borrowed `plug_cowboy`'s method of passing the network atoms: https://github.com/elixir-plug/plug_cowboy/blob/v2.6.0/lib/plug/cowboy.ex#L360-L361

