### PR TITLE
Add start_server opt on README server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ defmodule HelloworldApp do
   def start(_type, _args) do
     children = [
       # ...
-      {GRPC.Server.Supervisor, endpoint: Helloworld.Endpoint, port: 50051}
+      {GRPC.Server.Supervisor, endpoint: Helloworld.Endpoint, port: 50051, start_server: true}
     ]
 
     opts = [strategy: :one_for_one, name: YourApp]


### PR DESCRIPTION
This is already [documented](https://github.com/elixir-grpc/grpc/blob/3cbd100c5aaf49720b36b67064e9e38530cacaea/lib/grpc/server/supervisor.ex#L6), but just to avoid some headache copy/pasting from the README.md 😅 