### PR TITLE
Add client request to telemetry metadata

### DIFF
--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -265,7 +265,7 @@ defmodule GRPC.Stub do
         accepted_compressors: accepted_compressors
     }
 
-    GRPC.Telemetry.client_span(stream, fn ->
+    GRPC.Telemetry.client_span(stream, request, fn ->
       do_call(req_stream, stream, request, opts)
     end)
   end

--- a/lib/grpc/telemetry.ex
+++ b/lib/grpc/telemetry.ex
@@ -23,9 +23,7 @@ defmodule GRPC.Telemetry do
   ### Metadata
 
     * `:stream` - the `%GRPC.Server.Stream{}` for the request
-    * `:function_name` - the name of the function called
-    * `:server` - the server module name
-    * `:endpoint` - the endpoint module name
+    * `:request` - the client request
 
   `:exception` events also include some error metadata:
 
@@ -110,8 +108,8 @@ defmodule GRPC.Telemetry do
   def client_rpc_start_name, do: @client_rpc_start_name
 
   @doc false
-  def client_span(stream, span_fn) do
-    start_metadata = %{stream: stream}
+  def client_span(stream, request, span_fn) do
+    start_metadata = %{stream: stream, request: request}
 
     :telemetry.span(@client_rpc, start_metadata, fn ->
       try do

--- a/test/grpc/integration/client_interceptor_test.exs
+++ b/test/grpc/integration/client_interceptor_test.exs
@@ -50,6 +50,14 @@ defmodule GRPC.Integration.ClientInterceptorTest do
   end
 
   test "client sends headers" do
+    client_prefix = GRPC.Telemetry.client_rpc_prefix()
+    stop_client_name = client_prefix ++ [:stop]
+    service_name = Helloworld.Greeter.Service.__meta__(:name)
+
+    attach_events([
+      stop_client_name
+    ])
+
     run_endpoint(HelloEndpoint, fn port ->
       {:ok, channel} =
         GRPC.Stub.connect("localhost:#{port}",
@@ -62,6 +70,15 @@ defmodule GRPC.Integration.ClientInterceptorTest do
       req = Helloworld.HelloRequest.new(name: "Elixir")
       {:ok, reply} = channel |> Helloworld.Greeter.Stub.say_hello(req)
       assert reply.message == "Hello, Elixir one two"
+
+      assert_received {^stop_client_name, _measurements, metadata}
+      assert %{stream: stream, request: ^req} = metadata
+
+      assert %{
+        channel: ^channel,
+        service_name: ^service_name,
+        method_name: "SayHello"
+      } = stream
     end)
   end
 

--- a/test/grpc/integration/client_interceptor_test.exs
+++ b/test/grpc/integration/client_interceptor_test.exs
@@ -75,10 +75,10 @@ defmodule GRPC.Integration.ClientInterceptorTest do
       assert %{stream: stream, request: ^req} = metadata
 
       assert %{
-        channel: ^channel,
-        service_name: ^service_name,
-        method_name: "SayHello"
-      } = stream
+               channel: ^channel,
+               service_name: ^service_name,
+               method_name: "SayHello"
+             } = stream
     end)
   end
 


### PR DESCRIPTION
## Description

Having the actual client request in the telemetry event can be useful to cover more use cases, e.g. if you want to log specifics of the requests you are doing.

__NOTE__: Not sure if this was considered and discarded already so I just went ahead and created the PR as this would be helpful for my use case.