### PR TITLE
Replace deprecated Logger.warn with Logger.warning

### DIFF
--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -167,7 +167,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     {:ok, req, state}
   catch
     :exit, :timeout ->
-      Logger.warn("Timeout when reading full body")
+      Logger.warning("Timeout when reading full body")
       info({:handling_timeout, self()}, req, state)
   end
 
@@ -458,7 +458,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   defp extract_subtype("application/grpc-web-text+" <> rest), do: {:ok, rest}
 
   defp extract_subtype(type) do
-    Logger.warn("Got unknown content-type #{type}, please create an issue.")
+    Logger.warning("Got unknown content-type #{type}, please create an issue.")
     {:ok, "proto"}
   end
 

--- a/lib/grpc/server/supervisor.ex
+++ b/lib/grpc/server/supervisor.ex
@@ -107,7 +107,7 @@ defmodule GRPC.Server.Supervisor do
         {endpoint, endpoint.__meta__(:servers)}
       rescue
         FunctionClauseError ->
-          Logger.warn(
+          Logger.warning(
             "deprecated: servers as argument of GRPC.Server.Supervisor, please use GRPC.Endpoint"
           )
 

--- a/lib/grpc/transport/http2.ex
+++ b/lib/grpc/transport/http2.ex
@@ -93,7 +93,7 @@ defmodule GRPC.Transport.HTTP2 do
   end
 
   defp append_encoding(headers, grpc_encoding) when is_binary(grpc_encoding) do
-    Logger.warn("grpc_encoding option is deprecated, please use compressor.")
+    Logger.warning("grpc_encoding option is deprecated, please use compressor.")
     [{"grpc-encoding", grpc_encoding} | headers]
   end
 

--- a/test/support/integration_test_case.ex
+++ b/test/support/integration_test_case.ex
@@ -37,7 +37,7 @@ defmodule GRPC.Integration.TestCase do
         result
 
       {:error, :eaddrinuse} ->
-        Logger.warn("Got eaddrinuse when reconnecting to #{server}:#{port}. retry: #{retry}")
+        Logger.warning("Got eaddrinuse when reconnecting to #{server}:#{port}. retry: #{retry}")
 
         if retry >= 1 do
           Process.sleep(500)


### PR DESCRIPTION
### Description

[`Logger.warn` was deprecated in Elixir 1.15](https://hexdocs.pm/logger/1.15.0/Logger.html#warn/2), so compiling projects with `elixir-grpc` on 1.15 or higher produces output like this:

```
==> grpc
Compiling 1 file (.erl)
Compiling 36 files (.ex)
warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
  lib/grpc/server/supervisor.ex:110: GRPC.Server.Supervisor.child_spec/3

warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
  lib/grpc/transport/http2.ex:96: GRPC.Transport.HTTP2.append_encoding/2

warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
  lib/grpc/server/adapters/cowboy/handler.ex:170: GRPC.Server.Adapters.Cowboy.Handler.info/3

warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
  lib/grpc/server/adapters/cowboy/handler.ex:461: GRPC.Server.Adapters.Cowboy.Handler.extract_subtype/1
```

This is just a quick `CMD+SHIFT+F` to replace all instances of `Logger.warn` with `Logger.warning`, nothing crazy.

### Note

I also see warnings like below, but I haven't looked into those:
```
warning: Protobuf.Decoder.decode/2 is undefined (module Protobuf.Decoder is not available or is yet to be defined)
  lib/grpc/codec/web_text.ex:27: GRPC.Codec.WebText.decode/2

warning: Protobuf.Encoder.encode/1 is undefined (module Protobuf.Encoder is not available or is yet to be defined)
  lib/grpc/codec/web_text.ex:9: GRPC.Codec.WebText.encode/1
```