### PR TITLE
Expose Server Address via gRPC Stream

### DIFF
--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -174,6 +174,10 @@ defmodule GRPC.Server.Adapters.Cowboy do
     Handler.get_headers(pid)
   end
 
+  def get_sock(%{pid: pid}) do
+    Handler.get_sock(pid)
+  end
+
   def get_peer(%{pid: pid}) do
     Handler.get_peer(pid)
   end

--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -142,6 +142,10 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     sync_call(pid, :get_headers)
   end
 
+  def get_sock(pid) do
+    sync_call(pid, :get_sock)
+  end
+
   def get_peer(pid) do
     sync_call(pid, :get_peer)
   end
@@ -210,6 +214,12 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   def info({:get_headers, ref, pid}, req, state) do
     headers = :cowboy_req.headers(req)
     send(pid, {ref, headers})
+    {:ok, req, state}
+  end
+
+  def info({:get_sock, ref, pid}, req, state) do
+    sock = :cowboy_req.sock(req)
+    send(pid, {ref, sock})
     {:ok, req, state}
   end
 

--- a/lib/grpc/stream.ex
+++ b/lib/grpc/stream.ex
@@ -14,4 +14,17 @@ defmodule GRPC.Stream do
     headers = adapter.get_headers(stream.payload)
     GRPC.Transport.HTTP2.decode_headers(headers)
   end
+
+  @doc """
+  Get server address (hostname and port)
+  """
+  @spec get_server_address(GRPC.Server.Stream.t() | GRPC.Client.Stream.t()) :: tuple()
+  def get_server_address(%GRPC.Server.Stream{adapter: adapter} = stream) do
+    {host, port} = adapter.get_sock(stream.payload)
+    {to_string(:inet_parse.ntoa(host)), port}
+  end
+
+  def get_server_address(%GRPC.Client.Stream{channel: channel}) do
+    {channel.host, channel.port}
+  end
 end


### PR DESCRIPTION
- Adds exposure to the gRPC server address via the gRPC stream.

We are currently in the process of updating services to follow opentelemetry semantics and a required attribute is [server.address](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/#common-attributes). With the current exposed APIs we could not find a way to access the server address details or the underlying request object to get this information.