### PR TITLE
Make server stream work with mint client and add keepalive.

### DIFF
--- a/lib/grpc/client/adapters/mint.ex
+++ b/lib/grpc/client/adapters/mint.ex
@@ -114,12 +114,16 @@ defmodule GRPC.Client.Adapters.Mint do
       |> Keyword.get(:transport_opts, [])
       |> Keyword.merge(ssl)
 
-    [transport_opts: Keyword.merge(@default_transport_opts, transport_opts)]
+    keep_alive = Keyword.get(opts, :keep_alive, false)
+
+    [transport_opts: Keyword.merge(@default_transport_opts, transport_opts), keep_alive: keep_alive]
   end
 
   defp connect_opts(_channel, opts) do
     transport_opts = Keyword.get(opts, :transport_opts, [])
-    [transport_opts: Keyword.merge(@default_transport_opts, transport_opts)]
+    keep_alive = Keyword.get(opts, :keep_alive, false)
+
+    [transport_opts: Keyword.merge(@default_transport_opts, transport_opts), keep_alive: keep_alive]
   end
 
   defp mint_scheme(%Channel{scheme: "https"} = _channel), do: :https

--- a/lib/grpc/client/adapters/mint/connection_process/state.ex
+++ b/lib/grpc/client/adapters/mint/connection_process/state.ex
@@ -1,12 +1,13 @@
 defmodule GRPC.Client.Adapters.Mint.ConnectionProcess.State do
   @moduledoc false
 
-  defstruct [:conn, :parent, requests: %{}, request_stream_queue: :queue.new()]
+  defstruct [:conn, :parent, :ping_ref, requests: %{}, request_stream_queue: :queue.new()]
 
   @type t :: %__MODULE__{
           conn: Mint.HTTP.t(),
           requests: map(),
-          parent: pid()
+          parent: pid(),
+          ping_ref: Mint.Types.request_ref() | nil
         }
 
   def new(conn, parent) do
@@ -15,6 +16,10 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcess.State do
 
   def update_conn(state, conn) do
     %{state | conn: conn}
+  end
+
+  def set_ping_ref(state, ref) do
+    %{state | ping_ref: ref}
   end
 
   def update_request_stream_queue(state, queue) do

--- a/lib/grpc/client/adapters/mint/stream_response_process.ex
+++ b/lib/grpc/client/adapters/mint/stream_response_process.ex
@@ -143,7 +143,8 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
         _from,
         %{responses: responses} = state
       ) do
-    {:reply, :ok, %{state | responses: [error | responses]}, {:continue, :produce_response}}
+
+    {:reply, :ok, %{state | done: true, responses: [error | responses]}, {:continue, :produce_response}}
   end
 
   def handle_call({:consume_response, :done}, _from, state) do


### PR DESCRIPTION
This is what I been using for a while in our application.

Changed connection open? check to :read so server streaming is seen as a valid state for the connection.

And added a keepalive to make sure the connection is still open of the server stream because if a service like nginx breaks the connection you won't get any notification so you will never close the connection even if it's already broken.

Also added some error handling cases so it won't cause any server errors.

#312 
