### PR TITLE
fix: add priv to package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule GRPC.Mixfile do
       maintainers: ["Bing Han", "Paulo Valente"],
       licenses: ["Apache 2"],
       links: %{"GitHub" => "https://github.com/elixir-grpc/grpc"},
-      files: ~w(mix.exs README.md lib src config LICENSE .formatter.exs)
+      files: ~w(mix.exs README.md lib src config priv LICENSE .formatter.exs)
     }
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GRPC.Mixfile do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
 
   def project do
     [
@@ -60,7 +60,7 @@ defmodule GRPC.Mixfile do
       maintainers: ["Bing Han", "Paulo Valente"],
       licenses: ["Apache 2"],
       links: %{"GitHub" => "https://github.com/elixir-grpc/grpc"},
-      files: ~w(mix.exs README.md lib src config priv LICENSE .formatter.exs)
+      files: ~w(mix.exs README.md lib src config priv/templates LICENSE .formatter.exs)
     }
   end
 


### PR DESCRIPTION
When I upgrade gRPC from `0.7.0` to `0.8.0`, the gRPC compile fails.
I found that the PR #351 introduces [`priv/templates/service.ex.eex`](https://github.com/elixir-grpc/grpc/pull/351/files#diff-842b12b3246674c7155c41ee4a23eb0051a0684ad7afe602933b14c92286a8ea), but it isn’t added to package.

### To Reproduce

1. `cd examples/helloworld`

2. Change `grpc` source to hex
```diff
diff --git a/examples/helloworld/mix.exs b/examples/helloworld/mix.exs
index 497b7b1..7ca52df 100644
--- a/examples/helloworld/mix.exs
+++ b/examples/helloworld/mix.exs
@@ -18,7 +18,7 @@ defmodule Helloworld.Mixfile do
 
   defp deps do
     [
-      {:grpc, path: "../../"},
+      {:grpc, "~> 0.8"},
       {:jason, "~> 1.3.0"},
       {:protobuf, "~> 0.11"},
       {:google_protos, "~> 0.3.0"},
```
3. `mix deps.get && mix compile`
```
==> grpc
Compiling 1 file (.erl)
Compiling 49 files (.ex)

== Compilation error in file lib/grpc/protoc/generator/service.ex ==
** (File.Error) could not read file "grpc/examples/helloworld/_build/dev/lib/grpc/priv/templates/service.ex.eex": no such file or directory
    (elixir 1.15.7) lib/file.ex:358: File.read!/1
    (eex 1.15.7) lib/eex.ex:259: EEx.compile_file/2
    lib/grpc/protoc/generator/service.ex:9: (module)
could not compile dependency :grpc, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile grpc --force", update it with "mix deps.update grpc" or clean it with "mix deps.clean grpc"
```