### PR TITLE
Translate errors from HTTP statuses

### DIFF
--- a/lib/grpc/client/adapters/gun.ex
+++ b/lib/grpc/client/adapters/gun.ex
@@ -245,11 +245,7 @@ defmodule GRPC.Client.Adapters.Gun do
                )}
           end
         else
-          {:error,
-           GRPC.RPCError.exception(
-             GRPC.Status.internal(),
-             "status got is #{status} instead of 200"
-           )}
+          {:error, GRPC.RPCError.from_status(status)}
         end
 
       {:response, :nofin, status, headers} ->
@@ -266,11 +262,7 @@ defmodule GRPC.Client.Adapters.Gun do
             {:response, headers, :nofin}
           end
         else
-          {:error,
-           GRPC.RPCError.exception(
-             GRPC.Status.internal(),
-             "status got is #{status} instead of 200"
-           )}
+          {:error, GRPC.RPCError.from_status(status)}
         end
 
       {:data, :fin, data} ->

--- a/lib/grpc/rpc_error.ex
+++ b/lib/grpc/rpc_error.ex
@@ -71,6 +71,23 @@ defmodule GRPC.RPCError do
     %{error | message: error.message || Status.status_message(error.status)}
   end
 
+  def from_status(401), do: exception(GRPC.Status.unauthorized(), status_message(401))
+  def from_status(403), do: exception(GRPC.Status.permission_denied(), status_message(403))
+  def from_status(404), do: exception(GRPC.Status.unimplemented(), status_message(404))
+  def from_status(429), do: exception(GRPC.Status.unavailable(), status_message(429))
+
+  def from_status(status) when status in [502, 503, 504] do
+    exception(GRPC.Status.unavailable(), status_message(status))
+  end
+
+  def from_status(status) do
+    exception(GRPC.Status.internal(), status_message(status))
+  end
+
+  defp status_message(status) do
+    "got http status #{status_code} instead of 200"
+  end
+
   defp parse_args([], acc), do: acc
 
   defp parse_args([{:status, status} | t], acc) when is_integer(status) do


### PR DESCRIPTION
This is inspired in how GRPC go approaches HTTP errors when performing GRPC requests.

This provides meaningful errors in different situations. For example, AWS load balancer replies with a 504 when there are no live instances. There, a `unavailable` error is much more fitting than `internal`.

For go implementation: https://github.com/grpc/grpc-go/blob/273fe145d03df516018cf4642e6987e027ffc0f5/internal/transport/http_util.go#L68
