### PR TITLE
Use persistent_term for cowboy dispatch

### DIFF
--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -223,6 +223,8 @@ defmodule GRPC.Server.Adapters.Cowboy do
       end
 
     dispatch = GRPC.Server.Adapters.Cowboy.Router.compile([{:_, handlers}])
+    dispatch_key = Module.concat(endpoint, Dispatch)
+    :persistent_term.put(dispatch_key, dispatch)
 
     idle_timeout = Keyword.get(opts, :idle_timeout) || :infinity
     num_acceptors = Keyword.get(opts, :num_acceptors) || @default_num_acceptors
@@ -232,7 +234,7 @@ defmodule GRPC.Server.Adapters.Cowboy do
     opts =
       Map.merge(
         %{
-          env: %{dispatch: dispatch},
+          env: %{dispatch: {:persistent_term, dispatch_key}},
           idle_timeout: idle_timeout,
           inactivity_timeout: idle_timeout,
           settings_timeout: idle_timeout,


### PR DESCRIPTION
Avoids unnecessary copying, which improves performance when there's a significant number of routes. Little or no impact for when the dispatching table is small.

Requires OTP 21.2. Since the library requires Elixir ~> 1.12, it already requries OTP 22+.