### PR TITLE
Fix elixir 1.17 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: [24.x, 25.x, 26.1.x]
-        elixir: [1.15.x]
+        otp: [24.x, 25.x, 26.1.x, 27.x]
+        elixir: [1.15.x, 1.17.x]
         include:
           - otp: 24.x
             elixir: 1.12.x
@@ -86,8 +86,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     strategy:
       matrix:
-        otp: [24.x, 25.x, 26.1.x]
-        elixir: [1.15.x]
+        otp: [24.x, 25.x, 26.1.x, 27.x]
+        elixir: [1.15.x, 1.17.x]
         include:
           - otp: 24.x
             elixir: 1.12.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: [24.x, 25.x, 26.1.x, 27.x]
-        elixir: [1.15.x, 1.17.x]
+        otp: [24.x, 25.x, 26.1.x]
+        elixir: [1.15.x]
         include:
           - otp: 24.x
             elixir: 1.12.x
@@ -86,8 +86,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' }}
     strategy:
       matrix:
-        otp: [24.x, 25.x, 26.1.x, 27.x]
-        elixir: [1.15.x, 1.17.x]
+        otp: [24.x, 25.x, 26.1.x]
+        elixir: [1.15.x]
         include:
           - otp: 24.x
             elixir: 1.12.x

--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -131,7 +131,7 @@ defmodule GRPC.Server do
       codecs = if http_transcode, do: [GRPC.Codec.JSON | codecs], else: codecs
 
       routes =
-        for {name, _, _, options} = rpc <- service_mod.__rpc_calls__, reduce: [] do
+        for {name, _, _, options} = rpc <- service_mod.__rpc_calls__(), reduce: [] do
           acc ->
             path = "/#{service_name}/#{name}"
 
@@ -147,7 +147,7 @@ defmodule GRPC.Server do
             [{:grpc, path} | acc]
         end
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, _, _, options} = rpc ->
+      Enum.each(service_mod.__rpc_calls__(), fn {name, _, _, options} = rpc ->
         func_name = name |> to_string |> Macro.underscore() |> String.to_atom()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -63,7 +63,7 @@ defmodule GRPC.Stub do
       service_name = service_mod.__meta__(:name)
 
       Enum.each(service_mod.__rpc_calls__(), fn {name, {_, req_stream}, {_, res_stream}, _options} =
-                                                rpc ->
+                                                  rpc ->
         func_name = name |> to_string |> Macro.underscore()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -62,7 +62,7 @@ defmodule GRPC.Stub do
       service_mod = opts[:service]
       service_name = service_mod.__meta__(:name)
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, {_, req_stream}, {_, res_stream}, _options} =
+      Enum.each(service_mod.__rpc_calls__(), fn {name, {_, req_stream}, {_, res_stream}, _options} =
                                                 rpc ->
         func_name = name |> to_string |> Macro.underscore()
         path = "/#{service_name}/#{name}"


### PR DESCRIPTION
Fix these warnings in elixir 1.17:

```
warning: using map.field notation (without parentheses) to invoke function Module.__rpc_calls__() is deprecated, you must add parentheses instead: remote.function()
```

Right now all projects that depend on `grpc` generate warnings on user project (because the warnings are generated in the macros that user projects are calling), which means it breaks user projects CI's in elixir 1.17 that use `--warnings-as-errors`