### PR TITLE
Allow configurable Mint adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,26 @@ iex> {:ok, channel} = GRPC.Stub.connect("localhost:50051", interceptors: [GRPC.C
 
 Check the [examples](examples) and [interop](interop) directories in the project's source code for some examples.
 
+## Client Adapter and Configuration
+
+The default adapter used by `GRPC.Stub.connect/2` is `GRPC.Client.Adapter.Gun`. Another option is to use `GRPC.Client.Adapters.Mint` instead, like so:
+
+```
+GRPC.Stub.connect("localhost:50051",
+  # Use Mint adapter instead of default Gun
+  adapter: GRPC.Client.Adapters.Mint
+)
+```
+
+The `GRPC.Client.Adapters.Mint` adapter accepts custom configuration. To do so, you can configure it from your mix application via:
+
+```
+// File: your application's config file.
+config :grpc, GRPC.Client.Adapters.Mint, custom_opts
+```
+
+The accepted options for configuration are the ones listed on [Mint.HTTP.connect/4](https://hexdocs.pm/mint/Mint.HTTP.html#connect/4-options)
+
 ## Features
 
 - Various kinds of RPC:

--- a/lib/grpc/client/adapters/mint.ex
+++ b/lib/grpc/client/adapters/mint.ex
@@ -15,7 +15,8 @@ defmodule GRPC.Client.Adapters.Mint do
 
   @impl true
   def connect(%{host: host, port: port} = channel, opts \\ []) do
-    opts = Keyword.merge(@default_connect_opts, connect_opts(channel, opts))
+    opts = connect_opts(channel, opts) |> merge_opts()
+
     Process.flag(:trap_exit, true)
 
     channel
@@ -120,6 +121,14 @@ defmodule GRPC.Client.Adapters.Mint do
   defp connect_opts(_channel, opts) do
     transport_opts = Keyword.get(opts, :transport_opts, [])
     [transport_opts: Keyword.merge(@default_transport_opts, transport_opts)]
+  end
+
+  # Merges default opts with application specific opts
+  # set via `config :grpc, GRPC.Client.Adapters.Mint, custom_opts`
+  defp merge_opts(opts) do
+    module_opts = Application.get_env(:grpc, __MODULE__, [])
+    opts = Keyword.merge(opts, module_opts)
+    Keyword.merge(@default_connect_opts, opts)
   end
 
   defp mint_scheme(%Channel{scheme: "https"} = _channel), do: :https

--- a/lib/grpc/client/adapters/mint.ex
+++ b/lib/grpc/client/adapters/mint.ex
@@ -17,8 +17,6 @@ defmodule GRPC.Client.Adapters.Mint do
   def connect(%{host: host, port: port} = channel, opts \\ []) do
     # Added :config_options to facilitate testing.
     {config_opts, opts} = Keyword.pop(opts, :config_options, [])
-    # Merges default opts with application specific opts set
-    # via `config :grpc, GRPC.Client.Adapters.Mint, custom_opts`
     module_opts = Application.get_env(:grpc, __MODULE__, config_opts)
 
     opts = connect_opts(channel, opts) |> merge_opts(module_opts)

--- a/lib/grpc/client/adapters/mint.ex
+++ b/lib/grpc/client/adapters/mint.ex
@@ -15,7 +15,13 @@ defmodule GRPC.Client.Adapters.Mint do
 
   @impl true
   def connect(%{host: host, port: port} = channel, opts \\ []) do
-    opts = connect_opts(channel, opts) |> merge_opts()
+    # Added :config_options to facilitate testing.
+    {config_opts, opts} = Keyword.pop(opts, :config_options, [])
+    # Merges default opts with application specific opts set
+    # via `config :grpc, GRPC.Client.Adapters.Mint, custom_opts`
+    module_opts = Application.get_env(:grpc, __MODULE__, config_opts)
+
+    opts = connect_opts(channel, opts) |> merge_opts(module_opts)
 
     Process.flag(:trap_exit, true)
 
@@ -123,10 +129,7 @@ defmodule GRPC.Client.Adapters.Mint do
     [transport_opts: Keyword.merge(@default_transport_opts, transport_opts)]
   end
 
-  # Merges default opts with application specific opts
-  # set via `config :grpc, GRPC.Client.Adapters.Mint, custom_opts`
-  defp merge_opts(opts) do
-    module_opts = Application.get_env(:grpc, __MODULE__, [])
+  defp merge_opts(opts, module_opts) do
     opts = Keyword.merge(opts, module_opts)
     Keyword.merge(@default_connect_opts, opts)
   end

--- a/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -75,7 +75,11 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcess do
   ## Callbacks
 
   @impl true
-  def init({scheme, host, port, opts}) do
+  def init({scheme, host, port, _opts}) do
+    # Bypassing opts for now since it prevents
+    # some connections from being established.
+    # TODO: look into why this is needed
+    opts = []
     case Mint.HTTP.connect(scheme, host, port, opts) do
       {:ok, conn} ->
         {:ok, State.new(conn, opts[:parent])}

--- a/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -75,11 +75,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcess do
   ## Callbacks
 
   @impl true
-  def init({scheme, host, port, _opts}) do
-    # Bypassing opts for now since it prevents
-    # some connections from being established.
-    # TODO: look into why this is needed
-    opts = []
+  def init({scheme, host, port, opts}) do
     case Mint.HTTP.connect(scheme, host, port, opts) do
       {:ok, conn} ->
         {:ok, State.new(conn, opts[:parent])}

--- a/test/grpc/client/adapters/mint_test.exs
+++ b/test/grpc/client/adapters/mint_test.exs
@@ -42,7 +42,7 @@ defmodule GRPC.Client.Adapters.MintTest do
 
       assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result
 
-      # Ensure that changing one of the options breaks things
+      # Ensure that changing one of the options via config_options also breaks things
       assert {:error, message} =
                Mint.connect(channel, config_options: [transport_opts: [ip: "256.0.0.0"]])
 

--- a/test/grpc/client/adapters/mint_test.exs
+++ b/test/grpc/client/adapters/mint_test.exs
@@ -18,7 +18,6 @@ defmodule GRPC.Client.Adapters.MintTest do
       channel = build(:channel, adapter: Mint, port: port, host: "localhost")
 
       assert {:ok, result} = Mint.connect(channel, [])
-
       assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result
     end
 

--- a/test/grpc/client/adapters/mint_test.exs
+++ b/test/grpc/client/adapters/mint_test.exs
@@ -33,5 +33,20 @@ defmodule GRPC.Client.Adapters.MintTest do
 
       assert message == "Error while opening connection: {:error, :badarg}"
     end
+
+    test "accepts config_options for application specific configuration", %{port: port} do
+      channel = build(:channel, adapter: Mint, port: port, host: "localhost")
+
+      assert {:ok, result} =
+               Mint.connect(channel, config_options: [transport_opts: [ip: :loopback]])
+
+      assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result
+
+      # Ensure that changing one of the options breaks things
+      assert {:error, message} =
+               Mint.connect(channel, config_options: [transport_opts: [ip: "256.0.0.0"]])
+
+      assert message == "Error while opening connection: {:error, :badarg}"
+    end
   end
 end

--- a/test/grpc/client/adapters/mint_test.exs
+++ b/test/grpc/client/adapters/mint_test.exs
@@ -15,14 +15,15 @@ defmodule GRPC.Client.Adapters.MintTest do
     end
 
     test "connects insecurely (default options)", %{port: port} do
-      channel = build(:channel, port: port, host: "localhost")
+      channel = build(:channel, adapter: Mint, port: port, host: "localhost")
 
       assert {:ok, result} = Mint.connect(channel, [])
+
       assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result
     end
 
     test "connects insecurely (custom options)", %{port: port} do
-      channel = build(:channel, port: port, host: "localhost")
+      channel = build(:channel, adapter: Mint, port: port, host: "localhost")
 
       assert {:ok, result} = Mint.connect(channel, transport_opts: [ip: :loopback])
       assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result


### PR DESCRIPTION
## Problem

The use case for this came from attempting to connect to a particular gRPC server which was rejecting the connection due to the default `transport_options` being used:

```
[
    timeout: :infinity,
    verify: :verify_peer,
    depth: 99,
    cacert_file: "...." # redacted
  ]
```

## Solution

After overriding `transport_options` I was able to connect to said server. I believe the ability to override these options could also be useful for others. This PR allows the adapter options to be set from the client application via:

```
config :grpc, GRPC.Client.Adapters.Mint, transport_opts: []
```