### PR TITLE
Require protobuf only in dev/test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule GRPC.Mixfile do
       {:jason, ">= 0.0.0", optional: true},
       {:cowlib, "~> 2.12"},
       {:castore, "~> 0.1 or ~> 1.0", optional: true},
-      {:protobuf, "~> 0.11"},
+      {:protobuf, "~> 0.11", only: [:dev, :test]},
       {:protobuf_generate, "~> 0.1.1", only: [:dev, :test]},
       {:googleapis,
        github: "googleapis/googleapis",


### PR DESCRIPTION
This fixes a potential regression on #351. 

On README it's stated:
```
    # We don't force protobuf as a dependency for more
    # flexibility on which protobuf library is used,
    # but you probably want to use it as well
```

At @coingaming we rely on this characteristic of `:grpc` to be able to use an internal fork of  `:protobuf`. Due to this change, we get a dependency conflict and aren't able to use `:grpc` v0.8+.