### PR TITLE
Add one-line logs with time

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.15.7-otp-26
+erlang 26.1.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.15.7-otp-26
-erlang 26.1.2

--- a/lib/grpc/client/interceptors/logger.ex
+++ b/lib/grpc/client/interceptors/logger.ex
@@ -41,7 +41,7 @@ defmodule GRPC.Client.Interceptors.Logger do
         log_result(result, level, grpc_type, stream, start, stop)
         result
       rescue
-        error ->
+        error in GRPC.RPCError ->
           log_error(error, stream)
 
           raise error

--- a/lib/grpc/client/interceptors/logger.ex
+++ b/lib/grpc/client/interceptors/logger.ex
@@ -28,7 +28,7 @@ defmodule GRPC.Client.Interceptors.Logger do
   end
 
   @impl GRPC.Client.Interceptor
-  def call(stream = %{grpc_type: grpc_type}, req, next, opts) do
+  def call(%{grpc_type: grpc_type} = stream, req, next, opts) do
     {time, result} = :timer.tc(next, [stream, req])
     level = Keyword.fetch!(opts, :level)
 

--- a/lib/grpc/client/interceptors/logger.ex
+++ b/lib/grpc/client/interceptors/logger.ex
@@ -14,7 +14,7 @@ defmodule GRPC.Client.Interceptors.Logger do
 
   ## Usage with custom level
 
-      {:ok, channel} = GRPC.Stub.connect("localhost:50051", interceptors: [{GRPC.Client.Interceptors.Logger, level: :warn}])
+      {:ok, channel} = GRPC.Stub.connect("localhost:50051", interceptors: [{GRPC.Client.Interceptors.Logger, level: :warning}])
   """
 
   @behaviour GRPC.Client.Interceptor

--- a/test/grpc/client/interceptors/logger_test.exs
+++ b/test/grpc/client/interceptors/logger_test.exs
@@ -31,7 +31,8 @@ defmodule GRPC.Client.Interceptors.LoggerTest do
         LoggerInterceptor.call(stream, request, next, opts)
       end)
 
-    assert logs =~ ~r/\[info\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> :ok \(\d+\.\d+ ms\)/
+    assert logs =~
+             ~r/\[info\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> :ok \(\d+\.\d+ ms\)/
   end
 
   test "allows customizing log level" do
@@ -47,7 +48,8 @@ defmodule GRPC.Client.Interceptors.LoggerTest do
         LoggerInterceptor.call(stream, request, next, opts)
       end)
 
-    assert logs =~ ~r/\[warn(?:ing)?\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> :ok \(\d+\.\d+ ms\)/
+    assert logs =~
+             ~r/\[warn(?:ing)?\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> :ok \(\d+\.\d+ ms\)/
   end
 
   @tag capture_log: true

--- a/test/grpc/client/interceptors/logger_test.exs
+++ b/test/grpc/client/interceptors/logger_test.exs
@@ -124,7 +124,12 @@ defmodule GRPC.Client.Interceptors.LoggerTest do
     opts = LoggerInterceptor.init(level: :info)
 
     assert_raise(RuntimeError, fn ->
-      LoggerInterceptor.call(stream, request, next, opts)
+      logs =
+        capture_log(fn ->
+          LoggerInterceptor.call(stream, request, next, opts)
+        end)
+
+      assert logs == ""
     end)
   end
 end

--- a/test/grpc/client/interceptors/logger_test.exs
+++ b/test/grpc/client/interceptors/logger_test.exs
@@ -31,7 +31,7 @@ defmodule GRPC.Client.Interceptors.LoggerTest do
         LoggerInterceptor.call(stream, request, next, opts)
       end)
 
-    assert logs =~ ~r/\[info\]\s+Call #{to_string(elem(@rpc, 0))} of #{@service_name}/
+    assert logs =~ ~r/\[info\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> :ok \(\d+\.\d+ ms\)/
   end
 
   test "allows customizing log level" do
@@ -47,7 +47,7 @@ defmodule GRPC.Client.Interceptors.LoggerTest do
         LoggerInterceptor.call(stream, request, next, opts)
       end)
 
-    assert logs =~ ~r/\[warn(?:ing)?\]\s+Call #{to_string(elem(@rpc, 0))} of #{@service_name}/
+    assert logs =~ ~r/\[warn(?:ing)?\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> :ok \(\d+\.\d+ ms\)/
   end
 
   @tag capture_log: true

--- a/test/grpc/client/interceptors/logger_test.exs
+++ b/test/grpc/client/interceptors/logger_test.exs
@@ -114,4 +114,17 @@ defmodule GRPC.Client.Interceptors.LoggerTest do
                ~r/\[error\]\s+Call #{@service_name}\.#{to_string(elem(@rpc, 0))} -> %GRPC.RPCError{status: 3, message: "Client specified an invalid argument"}/
     end)
   end
+
+  test "does not log when error is not a GRPC.RPCError" do
+    Logger.configure(level: :all)
+
+    request = %FakeRequest{}
+    stream = %Stream{grpc_type: :unary, rpc: @rpc, service_name: @service_name}
+    next = fn _stream, _request -> raise "oops" end
+    opts = LoggerInterceptor.init(level: :info)
+
+    assert_raise(RuntimeError, fn ->
+      LoggerInterceptor.call(stream, request, next, opts)
+    end)
+  end
 end


### PR DESCRIPTION
## Context 

To properly observe our systems in unary calls, using one-line logs allows the user to see the elapsed time in a single place without joining two separate lines.

## Solution 

Use timer to measure time and log while maintaining the same behavior.

cc/ @polvalente 