### PR TITLE
fix: Use atom in pattern matching of http version

### DIFF
--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -619,7 +619,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     {:ok, "proto"}
   end
 
-  defp transcode?(%{version: "HTTP/1.1"}), do: true
+  defp transcode?(%{version: :"HTTP/1.1"}), do: true
 
   defp transcode?(req) do
     case find_content_type_subtype(req) do


### PR DESCRIPTION
cowboy:http_version seems to be an atom