### PR TITLE
add better logging for mint adapter in case of connection error

### DIFF
--- a/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -81,12 +81,18 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcess do
         {:ok, State.new(conn, opts[:parent])}
 
       {:error, reason} ->
-        Logger.error("unable to establish a connection. reason: #{inspect(reason)}")
+        Logger.error(
+          "unable to establish a connection to #{scheme}://#{host}:#{port}. reason: #{inspect(reason)}"
+        )
+
         {:stop, reason}
     end
   catch
     :exit, reason ->
-      Logger.error("unable to establish a connection. reason: #{inspect(reason)}")
+      Logger.error(
+        "unable to establish a connection to #{scheme}://#{host}:#{port}. reason: #{inspect(reason)}"
+      )
+
       {:stop, reason}
   end
 


### PR DESCRIPTION
Hi,

a very simple change to also print the endpoint when a connection error is logged, useful in case the application connects to multiple services