### PR TITLE
Access mode detection (transcode vs grpcweb vs grpc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,26 @@ An Elixir implementation of [gRPC](http://www.grpc.io/).
 
 ## Table of contents
 
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Simple RPC](#simple-rpc)
-  - [HTTP Transcoding](#http-transcoding)
-  - [Start Application](#start-application)
-- [Features](#features)
-- [Benchmark](#benchmark)
-- [Contributing](#contributing)
+-   [Installation](#installation)
+-   [Usage](#usage)
+    -   [Simple RPC](#simple-rpc)
+    -   [HTTP Transcoding](#http-transcoding)
+    -   [Start Application](#start-application)
+-   [Features](#features)
+-   [Benchmark](#benchmark)
+-   [Contributing](#contributing)
 
 ## Installation
 
 The package can be installed as:
 
-  ```elixir
-  def deps do
-    [
-      {:grpc, "~> 0.9"}
-    ]
-  end
-  ```
+```elixir
+def deps do
+  [
+    {:grpc, "~> 0.9"}
+  ]
+end
+```
 
 ## Usage
 
@@ -96,7 +96,7 @@ end
 
 We will use this module [in the gRPC server startup section](#start-application).
 
-**__Note:__** For other types of RPC call like streams see [here](interop/lib/interop/server.ex).
+****Note:**** For other types of RPC call like streams see [here](interop/lib/interop/server.ex).
 
 ### **HTTP Transcoding**
 
@@ -152,6 +152,7 @@ mix protobuf.generate \
 ```
 
 3. Enable http_transcode option in your Server module
+
 ```elixir
 defmodule Helloworld.Greeter.Server do
   use GRPC.Server,
@@ -169,7 +170,12 @@ See full application code in [helloworld_transcoding](examples/helloworld_transc
 
 ### **CORS**
 
-When accessing gRPC from a browser via HTTP transcoding or gRPC-Web, CORS headers may be required for the browser to allow access to the gRPC endpoint. Adding CORS headers can be done by using the included `Interceptor` in your `Endpoint` module:
+When accessing gRPC from a browser via HTTP transcoding or gRPC-Web, CORS headers may be required for the browser to allow access to the gRPC endpoint. Adding CORS headers can be done by using the included `Interceptor` in your `Endpoint` module, configuring it with an `allow_origin` and, optionally, `allow_headers`:
+
+-   `allow_origin` - Required. A string containing the allowed origin, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string.
+-   `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. If not provided, the value of the `"access-control-request-headers"` request header from the client will be used in the response.
+
+Example:
 
 ```elixir
 # Define your endpoint
@@ -177,28 +183,10 @@ defmodule Helloworld.Endpoint do
   use GRPC.Endpoint
 
   intercept GRPC.Server.Interceptors.Logger
-  intercept GRPC.Server.Interceptors.CORS
+  intercept GRPC.Server.Interceptors.CORS, allow_origin: "mydomain.io"
   run Helloworld.Greeter.Server
 end
 ```
-
-By default, the CORS `Interceptor` responds to CORS requests with a permissive response that allows *all* points of origin to access the service. This may be undesirable, particularly in production environments. For this reason, both the allowed origin and headers are configurable:
-
-```elixir
-# Define your endpoint
-defmodule Helloworld.Endpoint do
-  use GRPC.Endpoint
-
-  intercept GRPC.Server.Interceptors.Logger
-  intercept GRPC.Server.Interceptors.CORS, allow_origin: "mydomain.com", allow_headers: "Authorization"
-  run Helloworld.Greeter.Server
-end
-```
-
-The set of configuration directives supported include:
-
-  * `allow_origin` - A string containing the allowed origin(s), or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to `"*"`, which will allow all origins to access this endpoint.
-  * `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to the value of the `"access-control-request-headers"` request header from the client.
 
 ### **Start Application**
 
@@ -256,18 +244,18 @@ The accepted options for configuration are the ones listed on [Mint.HTTP.connect
 
 ## Features
 
-- Various kinds of RPC:
-  - [Unary](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc)
-  - [Server-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc)
-  - [Client-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#client-streaming-rpc)
-  - [Bidirectional-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc)
-- [HTTP Transcoding](https://cloud.google.com/endpoints/docs/grpc/transcoding)
-- [TLS Authentication](https://grpc.io/docs/guides/auth/#supported-auth-mechanisms)
-- [Error handling](https://grpc.io/docs/guides/error/)
-- Interceptors (See [`GRPC.Endpoint`](https://github.com/elixir-grpc/grpc/blob/master/lib/grpc/endpoint.ex))
-- [Connection Backoff](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md)
-- Data compression
-- [gRPC Reflection](https://github.com/elixir-grpc/grpc-reflection)
+-   Various kinds of RPC:
+    -   [Unary](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc)
+    -   [Server-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc)
+    -   [Client-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#client-streaming-rpc)
+    -   [Bidirectional-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc)
+-   [HTTP Transcoding](https://cloud.google.com/endpoints/docs/grpc/transcoding)
+-   [TLS Authentication](https://grpc.io/docs/guides/auth/#supported-auth-mechanisms)
+-   [Error handling](https://grpc.io/docs/guides/error/)
+-   Interceptors (See [`GRPC.Endpoint`](https://github.com/elixir-grpc/grpc/blob/master/lib/grpc/endpoint.ex))
+-   [Connection Backoff](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md)
+-   Data compression
+-   [gRPC Reflection](https://github.com/elixir-grpc/grpc-reflection)
 
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ end
 
 We will use this module [in the gRPC server startup section](#start-application).
 
-****Note:**** For other types of RPC call like streams see [here](interop/lib/interop/server.ex).
+**Note:** For other types of RPC call like streams see [here](interop/lib/interop/server.ex).
 
 ### **HTTP Transcoding**
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ An Elixir implementation of [gRPC](http://www.grpc.io/).
 
 ## Table of contents
 
--   [Installation](#installation)
--   [Usage](#usage)
-    -   [Simple RPC](#simple-rpc)
-    -   [HTTP Transcoding](#http-transcoding)
-    -   [Start Application](#start-application)
--   [Features](#features)
--   [Benchmark](#benchmark)
--   [Contributing](#contributing)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Simple RPC](#simple-rpc)
+  - [HTTP Transcoding](#http-transcoding)
+  - [Start Application](#start-application)
+- [Features](#features)
+- [Benchmark](#benchmark)
+- [Contributing](#contributing)
 
 ## Installation
 
@@ -172,8 +172,8 @@ See full application code in [helloworld_transcoding](examples/helloworld_transc
 
 When accessing gRPC from a browser via HTTP transcoding or gRPC-Web, CORS headers may be required for the browser to allow access to the gRPC endpoint. Adding CORS headers can be done by using the included `Interceptor` in your `Endpoint` module, configuring it with an `allow_origin` and, optionally, `allow_headers`:
 
--   `allow_origin` - Required. A string containing the allowed origin, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string.
--   `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. If not provided, the value of the `"access-control-request-headers"` request header from the client will be used in the response.
+- `allow_origin` - Required. A string containing the allowed origin, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string.
+- `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. If not provided, the value of the `"access-control-request-headers"` request header from the client will be used in the response.
 
 Example:
 
@@ -244,18 +244,18 @@ The accepted options for configuration are the ones listed on [Mint.HTTP.connect
 
 ## Features
 
--   Various kinds of RPC:
-    -   [Unary](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc)
-    -   [Server-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc)
-    -   [Client-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#client-streaming-rpc)
-    -   [Bidirectional-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc)
--   [HTTP Transcoding](https://cloud.google.com/endpoints/docs/grpc/transcoding)
--   [TLS Authentication](https://grpc.io/docs/guides/auth/#supported-auth-mechanisms)
--   [Error handling](https://grpc.io/docs/guides/error/)
--   Interceptors (See [`GRPC.Endpoint`](https://github.com/elixir-grpc/grpc/blob/master/lib/grpc/endpoint.ex))
--   [Connection Backoff](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md)
--   Data compression
--   [gRPC Reflection](https://github.com/elixir-grpc/grpc-reflection)
+- Various kinds of RPC:
+  - [Unary](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc)
+  - [Server-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc)
+  - [Client-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#client-streaming-rpc)
+  - [Bidirectional-streaming](https://grpc.io/docs/what-is-grpc/core-concepts/#bidirectional-streaming-rpc)
+- [HTTP Transcoding](https://cloud.google.com/endpoints/docs/grpc/transcoding)
+- [TLS Authentication](https://grpc.io/docs/guides/auth/#supported-auth-mechanisms)
+- [Error handling](https://grpc.io/docs/guides/error/)
+- Interceptors (See [`GRPC.Endpoint`](https://github.com/elixir-grpc/grpc/blob/master/lib/grpc/endpoint.ex))
+- [Connection Backoff](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md)
+- Data compression
+- [gRPC Reflection](https://github.com/elixir-grpc/grpc-reflection)
 
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ See full application code in [helloworld_transcoding](examples/helloworld_transc
 
 ### **CORS**
 
-When accessing grpc from a browser via http transcoding or grpcweb, CORS headers may be required for the browser to allow access to the grpc endpoint. Adding CORS headers is can be done by using the included `Interceptor` in your `Endpoint` module:
+When accessing gRPC from a browser via HTTP transcoding or gRPC-Web, CORS headers may be required for the browser to allow access to the gRPC endpoint. Adding CORS headers can be done by using the included `Interceptor` in your `Endpoint` module:
 
 ```elixir
 # Define your endpoint

--- a/README.md
+++ b/README.md
@@ -167,6 +167,39 @@ end
 
 See full application code in [helloworld_transcoding](examples/helloworld_transcoding) example.
 
+### **CORS**
+
+When accessing grpc from a browser via http transcoding or grpcweb, CORS headers may be required for the browser to allow access to the grpc endpoint. Adding CORS headers is can be done by using the included `Interceptor` in your `Endpoint` module:
+
+```elixir
+# Define your endpoint
+defmodule Helloworld.Endpoint do
+  use GRPC.Endpoint
+
+  intercept GRPC.Server.Interceptors.Logger
+  intercept GRPC.Server.Interceptors.CORS
+  run Helloworld.Greeter.Server
+end
+```
+
+By default, the CORS `Interceptor` responds to CORS requests with a permissive response that allows *all* points of origin to access the service. This may be undesirable, particularly in production environments. For this reason, both the allowed origin and headers are configurable:
+
+```elixir
+# Define your endpoint
+defmodule Helloworld.Endpoint do
+  use GRPC.Endpoint
+
+  intercept GRPC.Server.Interceptors.Logger
+  intercept GRPC.Server.Interceptors.CORS, allow_origin: "mydomain.com", allow_headers: "Authorization"
+  run Helloworld.Greeter.Server
+end
+```
+
+The set of configuration directives supported include:
+
+  * `allow_origin` - A string containing the allowed origin(s), or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to `"*"`, which will allow all origins to access this endpoint.
+  * `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to the value of the `"access-control-request-headers"` request header from the client.
+
 ### **Start Application**
 
 1. Start gRPC Server in your supervisor tree or Application module:

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The accepted options for configuration are the ones listed on [Mint.HTTP.connect
 - [HTTP Transcoding](https://cloud.google.com/endpoints/docs/grpc/transcoding)
 - [TLS Authentication](https://grpc.io/docs/guides/auth/#supported-auth-mechanisms)
 - [Error handling](https://grpc.io/docs/guides/error/)
-- Interceptors (See [`GRPC.Endpoint`](https://github.com/elixir-grpc/grpc/blob/master/lib/grpc/endpoint.ex))
+- [Interceptors](`GRPC.Endpoint`)
 - [Connection Backoff](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md)
 - Data compression
 - [gRPC Reflection](https://github.com/elixir-grpc/grpc-reflection)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An Elixir implementation of [gRPC](http://www.grpc.io/).
 - [Usage](#usage)
   - [Simple RPC](#simple-rpc)
   - [HTTP Transcoding](#http-transcoding)
+  - [CORS](#cors)
   - [Start Application](#start-application)
 - [Features](#features)
 - [Benchmark](#benchmark)
@@ -170,10 +171,7 @@ See full application code in [helloworld_transcoding](examples/helloworld_transc
 
 ### **CORS**
 
-When accessing gRPC from a browser via HTTP transcoding or gRPC-Web, CORS headers may be required for the browser to allow access to the gRPC endpoint. Adding CORS headers can be done by using the included `Interceptor` in your `Endpoint` module, configuring it with an `allow_origin` and, optionally, `allow_headers`:
-
-- `allow_origin` - Required. A string containing the allowed origin, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string.
-- `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. If not provided, the value of the `"access-control-request-headers"` request header from the client will be used in the response.
+When accessing gRPC from a browser via HTTP transcoding or gRPC-Web, CORS headers may be required for the browser to allow access to the gRPC endpoint. Adding CORS headers can be done by using `GRPC.Server.Interceptors.CORS` as an interceptor in your `GRPC.Endpoint` module, configuring it as decribed in the module documentation:
 
 Example:
 

--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -179,8 +179,7 @@ defmodule GRPC.Server do
                 | service_name: unquote(service_name),
                   method_name: unquote(to_string(name)),
                   grpc_type: unquote(grpc_type),
-                  http_method: unquote(http_method),
-                  http_transcode: unquote(http_transcode)
+                  http_method: unquote(http_method)
               },
               unquote(Macro.escape(put_elem(rpc, 0, func_name))),
               unquote(func_name)
@@ -253,7 +252,7 @@ defmodule GRPC.Server do
            codec: codec,
            adapter: adapter,
            payload: payload,
-           http_transcode: true
+           client_type: :web
          } = stream,
          func_name
        ) do

--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -252,7 +252,7 @@ defmodule GRPC.Server do
            codec: codec,
            adapter: adapter,
            payload: payload,
-           client_type: :web
+           access_mode: :http_transcoding
          } = stream,
          func_name
        ) do
@@ -272,7 +272,7 @@ defmodule GRPC.Server do
   end
 
   defp do_handle_request(false, res_stream, %{is_preflight?: true} = stream, func_name) do
-   call_with_interceptors(res_stream, func_name, stream, [])
+    call_with_interceptors(res_stream, func_name, stream, [])
   end
 
   defp do_handle_request(

--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -61,6 +61,8 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
          {:ok, codec} <- find_codec(sub_type, content_type, server),
          {:ok, compressor} <- find_compressor(req, server) do
       stream_pid = self()
+      http_transcode = access_mode == :http_transcoding
+
       stream = %GRPC.Server.Stream{
         server: server,
         endpoint: endpoint,
@@ -69,7 +71,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
         local: opts[:local],
         codec: codec,
         http_method: http_method,
-        http_transcode: access_mode == :http_transcoding,
+        http_transcode: http_transcode,
         compressor: compressor,
         is_preflight?: preflight?(req),
         access_mode: access_mode

--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -69,6 +69,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
         local: opts[:local],
         codec: codec,
         http_method: http_method,
+        http_transcode: client_type == :web,
         compressor: compressor,
         is_preflight?: preflight?(req),
         client_type: client_type

--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -70,6 +70,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
         codec: codec,
         http_method: http_method,
         compressor: compressor,
+        is_preflight?: preflight?(req),
         http_transcode: transcode?(req)
       }
 
@@ -627,6 +628,9 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
       _ -> false
     end
   end
+  defp preflight?(%{method: method}), do: method == "OPTIONS"
+  defp preflight?(%{method: "OPTIONS"}), do: true
+  defp preflight?(_), do: false
 
   defp send_error(req, error, state, reason) do
     trailers = HTTP2.server_trailers(error.status, error.message)

--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -608,7 +608,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     end
   end
 
-  defp extract_subtype("application/json"), do: {:ok, :grpc, "json"}
+  defp extract_subtype("application/json"), do: {:ok, :web, "json"}
   defp extract_subtype("application/grpc"), do: {:ok, :grpc, "proto"}
   defp extract_subtype("application/grpc+"), do: {:ok, :grpc, "proto"}
   defp extract_subtype("application/grpc;"), do: {:ok, :grpc, "proto"}
@@ -628,7 +628,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   end
 
   defp resolve_client_type(%{version: "HTTP/1.1"}, _detected_client_type, _type_subtype), do: :web
-  defp resolve_client_type(_req, _detected_client_type, "json"), do: :web
   defp resolve_client_type(%{method: "OPTIONS"}, _detected_client_type, _type_subtype), do: :grpcweb
   defp resolve_client_type(_req, detected_client_type, _type_subtype), do: detected_client_type
 

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -43,7 +43,7 @@ defmodule GRPC.Server.Interceptors.CORS do
 
   @impl true
   def call(req, stream, next, allowed) do
-    if stream.client_type != :grpc do
+    if stream.access_mode != :grpc do
       stream.adapter.set_headers(stream.payload, %{
         "access-control-allow-origin" => resolve_allowed(req, stream, allowed),
         "access-control-allow-headers" => "content-type, x-grpc-web, x-user-agent, x-api-key"

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -31,13 +31,13 @@ defmodule GRPC.Server.Interceptors.CORS do
 
   @behaviour GRPC.Server.Interceptor
   @impl true
-  def init(opts) do
+  def init(opts \\ []) do
     # the funky first clause matches a 2-arity remote is_function
     # note that this function is run in the context of a macro, which brings some limitations with it
     case Keyword.get(opts, :allow) do
       {:&, [], [{:/, [], [_signature, 2]}]} = fun -> fun
       static when is_binary(static) -> static
-      _ ->"*"
+      _ -> "*"
     end
   end
 

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -1,6 +1,6 @@
 defmodule GRPC.Server.Interceptors.CORS do
   @moduledoc """
-  Sends CORS headers when the client is calling the rpc via web transcoding or grpcweb.
+  Sends CORS headers when the client is using RPC via Web transcoding or gRPC-web.
 
   ## Options
 

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -4,8 +4,8 @@ defmodule GRPC.Server.Interceptors.CORS do
 
   ## Options
 
-    * `allow_origin` - A string containing the allowed origin(s), or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to `"*"`, which will allow all origins to access this endpoint.
-    * `allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to the value of the `"access-control-request-headers"` request header from the client.
+    * `allow_origin` - Required. A string containing the allowed origin, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string.
+    *`allow_headers` - A string containing the allowed headers, or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. If not defined, the value of the `"access-control-request-headers"` request header from the client will be used in the response.
 
   ## Usage
 
@@ -39,7 +39,6 @@ defmodule GRPC.Server.Interceptors.CORS do
       case Keyword.get(opts, :allow_origin) do
         {:&, [], [{:/, [], [_signature, 2]}]} = fun -> fun
         static when is_binary(static) -> static
-        _ -> "*"
       end
 
     allow_headers =

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -39,6 +39,7 @@ defmodule GRPC.Server.Interceptors.CORS do
       case Keyword.get(opts, :allow_origin) do
         {:&, [], [{:/, [], [_signature, 2]}]} = fun -> fun
         static when is_binary(static) -> static
+        _ -> raise ArgumentError, message: "allow_header must be a string or a 2-arity remote function"
       end
 
     allow_headers =

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -1,0 +1,61 @@
+defmodule GRPC.Server.Interceptors.CORS do
+  @moduledoc """
+  Sends CORS headers when the client is calling the rpc via web transcoding or grpcweb.
+
+  ## Options
+
+    * `allowed` - A string contianing the allowed origin(s), or a remote function (e.g. `&MyApp.MyModule.function/2)`) which takes a `req` and a `stream` and returns a string. Defaults to `"*"`, which will allow all origins to access this endpoint.
+
+  ## Usage
+
+      defmodule Your.Endpoint do
+        use GRPC.Endpoint
+
+        intercept GRPC.Server.Interceptors.CORS
+      end
+
+      defmodule Your.Endpoint do
+        use GRPC.Endpoint
+
+        intercept GRPC.Server.Interceptors.CORS, allowed: "some.origin"
+      end
+
+
+      defmodule Your.Endpoint do
+        use GRPC.Endpoint
+
+        def allowed_origin(req, stream), do: "calculated.origin"
+        intercept GRPC.Server.Interceptors.CORS, allowed: &Your.Endpoint.allowed_origin/2
+      end
+  """
+
+  @behaviour GRPC.Server.Interceptor
+  @impl true
+  def init(opts) do
+    # the funky first clause matches a 2-arity remote is_function
+    # note that this function is run in the context of a macro, which brings some limitations with it
+    case Keyword.get(opts, :allow) do
+      {:&, [], [{:/, [], [_signature, 2]}]} = fun -> fun
+      static when is_binary(static) -> static
+      _ ->"*"
+    end
+  end
+
+  @impl true
+  def call(req, stream, next, allowed) do
+    if stream.client_type != :grpc do
+      stream.adapter.set_headers(stream.payload, %{
+        "access-control-allow-origin" => resolve_allowed(req, stream, allowed),
+        "access-control-allow-headers" => "content-type, x-grpc-web, x-user-agent, x-api-key"
+      })
+    end
+
+    next.(req, stream)
+  end
+
+  defp resolve_allowed(req, stream, allowed_fn) when is_function(allowed_fn, 2) do
+    allowed_fn.(req, stream)
+  end
+
+  defp resolve_allowed(_req, _stream, allowed), do: allowed
+end

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -41,10 +41,18 @@ defmodule GRPC.Server.Interceptors.CORS do
     # This is not a full-on Macro context, so binary concatenations and
     # variables are handled before this step.
 
-    opts = Keyword.validate!(opts, [:allow_origin, allow_headers: nil])
+    # TODO: use Keyword.validate! once we drop support for Elixir < 1.13
+
+    {allow_origin, opts} = Keyword.pop(opts, :allow_origin)
+    {allow_headers, opts} = Keyword.pop(opts, :allow_headers)
+
+    if opts != [] do
+      raise ArgumentError,
+            "valid keys are [:allow_origin, :allow_headers], got: #{inspect(opts)}"
+    end
 
     allow_origin =
-      case Keyword.get(opts, :allow_origin) do
+      case allow_origin do
         {:&, [], [{:/, [], [_signature, 2]}]} = fun ->
           fun
 
@@ -57,7 +65,7 @@ defmodule GRPC.Server.Interceptors.CORS do
       end
 
     allow_headers =
-      case Keyword.get(opts, :allow_headers) do
+      case allow_headers do
         {:&, [], [{:/, [], [_signature, 2]}]} = fun ->
           fun
 

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -43,7 +43,8 @@ defmodule GRPC.Server.Interceptors.CORS do
 
   @impl true
   def call(req, stream, next, allowed) do
-    if stream.access_mode != :grpc do
+    if stream.access_mode != :grpc and
+         Map.get(stream.http_request_headers, "sec-fetch-mode") == "cors" do
       stream.adapter.set_headers(stream.payload, %{
         "access-control-allow-origin" => resolve_allowed(req, stream, allowed),
         "access-control-allow-headers" => "content-type, x-grpc-web, x-user-agent, x-api-key"

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -39,7 +39,7 @@ defmodule GRPC.Server.Interceptors.CORS do
       case Keyword.get(opts, :allow_origin) do
         {:&, [], [{:/, [], [_signature, 2]}]} = fun -> fun
         static when is_binary(static) -> static
-        _ -> raise ArgumentError, message: "allow_header must be a string or a 2-arity remote function"
+        _ -> raise ArgumentError, message: "allow_origin must be a string or a 2-arity remote function"
       end
 
     allow_headers =

--- a/lib/grpc/server/stream.ex
+++ b/lib/grpc/server/stream.ex
@@ -40,6 +40,7 @@ defmodule GRPC.Server.Stream do
           is_preflight?: boolean(),
           # For http transcoding
           http_method: GRPC.Server.Router.http_method(),
+            http_request_headers: map(),
           http_transcode: boolean(),
           __interface__: map()
         }
@@ -61,6 +62,7 @@ defmodule GRPC.Server.Stream do
             compressor: nil,
             is_preflight?: false,
             http_method: :post,
+            http_request_headers: %{},
             http_transcode: false,
             __interface__: %{send_reply: &__MODULE__.send_reply/3}
 

--- a/lib/grpc/server/stream.ex
+++ b/lib/grpc/server/stream.ex
@@ -40,6 +40,7 @@ defmodule GRPC.Server.Stream do
           is_preflight?: boolean(),
           # For http transcoding
           http_method: GRPC.Server.Router.http_method(),
+          http_transcode: boolean(),
           __interface__: map()
         }
 
@@ -60,6 +61,7 @@ defmodule GRPC.Server.Stream do
             compressor: nil,
             is_preflight?: false,
             http_method: :post,
+            http_transcode: false,
             __interface__: %{send_reply: &__MODULE__.send_reply/3}
 
   def send_reply(%{is_preflight?: true} = stream, _reply, opts) do
@@ -67,7 +69,7 @@ defmodule GRPC.Server.Stream do
   end
 
   def send_reply(
-        %{grpc_type: :server_stream, codec: codec, rpc: rpc, client_type: :web} = stream,
+        %{grpc_type: :server_stream, codec: codec, http_transcode: true, rpc: rpc} = stream,
         reply,
         opts
       ) do
@@ -77,7 +79,7 @@ defmodule GRPC.Server.Stream do
     do_send_reply(stream, [codec.encode(response), "\n"], opts)
   end
 
-  def send_reply(%{codec: codec, rpc: rpc, client_type: :web} = stream, reply, opts) do
+  def send_reply(%{codec: codec, http_transcode: true,  rpc: rpc} = stream, reply, opts) do
     rule = GRPC.Service.rpc_options(rpc, :http) || %{value: %{}}
     response = GRPC.Server.Transcode.map_response_body(rule.value, reply)
 
@@ -89,14 +91,14 @@ defmodule GRPC.Server.Stream do
   end
 
   defp do_send_reply(
-         %{adapter: adapter, codec: codec, client_type: client_type} = stream,
+         %{adapter: adapter, codec: codec, http_transcode: http_transcode} = stream,
          data,
          opts
        ) do
     opts =
       opts
       |> Keyword.put(:codec, codec)
-      |> Keyword.put(:http_transcode, client_type == :web)
+      |> Keyword.put(:http_transcode, http_transcode)
 
     adapter.send_reply(stream.payload, data, opts)
 

--- a/lib/grpc/server/stream.ex
+++ b/lib/grpc/server/stream.ex
@@ -40,7 +40,7 @@ defmodule GRPC.Server.Stream do
           is_preflight?: boolean(),
           # For http transcoding
           http_method: GRPC.Server.Router.http_method(),
-            http_request_headers: map(),
+          http_request_headers: map(),
           http_transcode: boolean(),
           __interface__: map()
         }
@@ -71,7 +71,8 @@ defmodule GRPC.Server.Stream do
   end
 
   def send_reply(
-        %{grpc_type: :server_stream, codec: codec, access_mode: :http_transcoding, rpc: rpc} = stream,
+        %{grpc_type: :server_stream, codec: codec, access_mode: :http_transcoding, rpc: rpc} =
+          stream,
         reply,
         opts
       ) do
@@ -81,7 +82,7 @@ defmodule GRPC.Server.Stream do
     do_send_reply(stream, [codec.encode(response), "\n"], opts)
   end
 
-  def send_reply(%{codec: codec, access_mode: :http_transcoding,  rpc: rpc} = stream, reply, opts) do
+  def send_reply(%{codec: codec, access_mode: :http_transcoding, rpc: rpc} = stream, reply, opts) do
     rule = GRPC.Service.rpc_options(rpc, :http) || %{value: %{}}
     response = GRPC.Server.Transcode.map_response_body(rule.value, reply)
 

--- a/lib/grpc/server/stream.ex
+++ b/lib/grpc/server/stream.ex
@@ -34,6 +34,8 @@ defmodule GRPC.Server.Stream do
           # compressor mainly is used in client decompressing, responses compressing should be set by
           # `GRPC.Server.set_compressor`
           compressor: module() | nil,
+          # notes that this is a preflight request, and not an actual request for data (e.g. in grpcweb)
+          is_preflight?: boolean(),
           # For http transcoding
           http_method: GRPC.Server.Router.http_method(),
           http_transcode: boolean(),
@@ -54,9 +56,14 @@ defmodule GRPC.Server.Stream do
             adapter: nil,
             local: nil,
             compressor: nil,
+            is_preflight?: false,
             http_method: :post,
             http_transcode: false,
             __interface__: %{send_reply: &__MODULE__.send_reply/3}
+
+  def send_reply(%{is_preflight?: true} = stream, _reply, opts) do
+    do_send_reply(stream, [], opts)
+  end
 
   def send_reply(
         %{grpc_type: :server_stream, codec: codec, http_transcode: true, rpc: rpc} = stream,

--- a/test/grpc/server/interceptors/cors_test.exs
+++ b/test/grpc/server/interceptors/cors_test.exs
@@ -1,0 +1,111 @@
+defmodule GRPC.Server.Interceptors.CORSTest.Endpoint do
+  use GRPC.Endpoint
+  intercept(GRPC.Server.Interceptors.CORS, allow: &GRPC.Server.Interceptors.CORSTest.allow_origin/2)
+end
+
+defmodule GRPC.Server.Interceptors.CORSTest do
+  use ExUnit.Case, async: false
+
+  alias GRPC.Server.Interceptors.CORS, as: CORSInterceptor
+  alias GRPC.Server.Stream
+
+  defmodule FakeRequest do
+    defstruct []
+  end
+
+  @server_name :server
+  @rpc {1, 2, 3}
+  @adaptor GRPC.Test.ServerAdapter
+  @function_header_value "from-function"
+
+  def allow_origin(_req, _stream), do: @function_header_value
+
+  test "Sends headers CORS for for http transcoding and grpcweb requests" do
+    request = %FakeRequest{}
+    stream = %Stream{adapter: @adaptor, server: @server_name, rpc: @rpc}
+
+    {:ok, :ok} =
+      CORSInterceptor.call(
+        request,
+        %{stream | access_mode: :http_transcode},
+        fn _request, _stream -> {:ok, :ok} end,
+        CORSInterceptor.init()
+      )
+
+    assert_received({:setting_headers, _headers}, "Failed to set CORS headers during grpcweb")
+
+    {:ok, :ok} =
+      CORSInterceptor.call(
+        request,
+        %{stream | access_mode: :grpcweb},
+        fn _request, _stream -> {:ok, :ok} end,
+        CORSInterceptor.init()
+      )
+
+    assert_received({:setting_headers, _headers}, "Failed to set CORS headers during grpcweb")
+  end
+
+  test "Does not send CORS headers for normal grpc requests" do
+    request = %FakeRequest{}
+    stream = %Stream{adapter: @adaptor, server: @server_name}
+
+    {:ok, :ok} =
+      CORSInterceptor.call(
+        request,
+        %{stream | access_mode: :grpc},
+        fn _request, _stream -> {:ok, :ok} end,
+        CORSInterceptor.init()
+      )
+
+    refute_received({:setting_headers, _headers}, "Set CORS headers during grpc")
+  end
+
+  test "Default CORS allow origin header allows all" do
+    request = %FakeRequest{}
+    stream = %Stream{adapter: @adaptor, server: @server_name, access_mode: :grpcweb}
+
+    {:ok, :ok} =
+      CORSInterceptor.call(
+        request,
+        stream,
+        fn _request, _stream -> {:ok, :ok} end,
+        CORSInterceptor.init()
+      )
+    assert_received({:setting_headers, %{"access-control-allow-origin" => "*"}}, "Incorrect default header")
+  end
+
+  test "CORS allow origin header value is configuraable with a static string" do
+    request = %FakeRequest{}
+    stream = %Stream{adapter: @adaptor, server: @server_name, access_mode: :grpcweb}
+    domain = "https://mydomain.io"
+
+    {:ok, :ok} =
+      CORSInterceptor.call(
+        request,
+        %{stream | access_mode: :grpcweb},
+        fn _request, _stream -> {:ok, :ok} end,
+        CORSInterceptor.init(allow: domain)
+      )
+
+    assert_received({:setting_headers, %{"access-control-allow-origin" => ^domain}}, "Incorrect static header")
+  end
+
+  test "CORS allow origin header value is configuraable with a two-arity function" do
+    request = %FakeRequest{}
+    stream = %Stream{adapter: @adaptor, server: @server_name, access_mode: :grpcweb}
+
+    # fetch the interceptor state from the fake endpoint
+    [{_interceptor, interceptor_state}] = GRPC.Server.Interceptors.CORSTest.Endpoint.__meta__(:interceptors)
+
+    {:ok, :ok} =
+      CORSInterceptor.call(
+        request,
+        %{stream | access_mode: :grpcweb},
+        fn _request, _stream -> {:ok, :ok} end,
+        interceptor_state
+      )
+
+    assert_received({:setting_headers, %{"access-control-allow-origin" => @function_header_value}}, "Incorrect header when using function")
+
+  end
+end

--- a/test/grpc/server/interceptors/cors_test.exs
+++ b/test/grpc/server/interceptors/cors_test.exs
@@ -159,7 +159,12 @@ defmodule GRPC.Server.Interceptors.CORSTest do
     stream = %{
       create_stream()
       | access_mode: :grpcweb,
-        http_request_headers: Map.put(@default_http_headers, "access-control-request-headers", @requested_allowed_headers)
+        http_request_headers:
+          Map.put(
+            @default_http_headers,
+            "access-control-request-headers",
+            @requested_allowed_headers
+          )
     }
 
     {:ok, :ok} =
@@ -171,7 +176,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
       )
 
     assert_received(
-      {:setting_headers, %{ "access-control-allow-headers" => @requested_allowed_headers }},
+      {:setting_headers, %{"access-control-allow-headers" => @requested_allowed_headers}},
       "Incorrect header when using function"
     )
   end
@@ -182,7 +187,12 @@ defmodule GRPC.Server.Interceptors.CORSTest do
     stream = %{
       create_stream()
       | access_mode: :grpcweb,
-        http_request_headers: Map.put(@default_http_headers, "access-control-request-headers", @requested_allowed_headers)
+        http_request_headers:
+          Map.put(
+            @default_http_headers,
+            "access-control-request-headers",
+            @requested_allowed_headers
+          )
     }
 
     allowed_headers = "Test"
@@ -196,7 +206,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
       )
 
     assert_received(
-      {:setting_headers, %{ "access-control-allow-headers" => ^allowed_headers }},
+      {:setting_headers, %{"access-control-allow-headers" => ^allowed_headers}},
       "Incorrect header when using function"
     )
   end
@@ -207,12 +217,17 @@ defmodule GRPC.Server.Interceptors.CORSTest do
     stream = %{
       create_stream()
       | access_mode: :grpcweb,
-        http_request_headers: Map.put(@default_http_headers, "access-control-request-headers", @requested_allowed_headers)
+        http_request_headers:
+          Map.put(
+            @default_http_headers,
+            "access-control-request-headers",
+            @requested_allowed_headers
+          )
     }
+
     # fetch the interceptor state from the fake endpoint
     [{_interceptor, interceptor_state}] =
       GRPC.Server.Interceptors.CORSTest.Endpoint.__meta__(:interceptors)
-
 
     {:ok, :ok} =
       CORSInterceptor.call(
@@ -223,7 +238,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
       )
 
     assert_received(
-      {:setting_headers, %{ "access-control-allow-headers" => @custom_allowed_headers }},
+      {:setting_headers, %{"access-control-allow-headers" => @custom_allowed_headers}},
       "Incorrect header when using function"
     )
   end

--- a/test/grpc/server/interceptors/cors_test.exs
+++ b/test/grpc/server/interceptors/cors_test.exs
@@ -63,7 +63,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         %{stream | access_mode: :http_transcode},
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init()
+        CORSInterceptor.init(allow_origin: "*")
       )
 
     assert_received({:setting_headers, _headers}, "Failed to set CORS headers during grpcweb")
@@ -73,7 +73,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         %{stream | access_mode: :grpcweb},
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init()
+        CORSInterceptor.init(allow_origin: "*")
       )
 
     assert_received({:setting_headers, _headers}, "Failed to set CORS headers during grpcweb")
@@ -88,7 +88,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         %{stream | access_mode: :grpc},
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init()
+        CORSInterceptor.init(allow_origin: "*")
       )
 
     refute_received({:setting_headers, _headers}, "Set CORS headers during grpc")
@@ -103,7 +103,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         stream,
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init()
+        CORSInterceptor.init(allow_origin: "*")
       )
 
     assert_received(
@@ -172,7 +172,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         %{stream | access_mode: :grpcweb},
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init()
+        CORSInterceptor.init(allow_origin: "*")
       )
 
     assert_received(
@@ -202,7 +202,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         %{stream | access_mode: :grpcweb},
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init(allow_headers: allowed_headers)
+        CORSInterceptor.init(allow_origin: "*", allow_headers: allowed_headers)
       )
 
     assert_received(
@@ -277,7 +277,7 @@ defmodule GRPC.Server.Interceptors.CORSTest do
         request,
         %{stream | access_mode: :grpcweb},
         fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init(allow: "*")
+        CORSInterceptor.init(allow_origin: "*")
       )
 
     refute_received({:setting_headers, _}, "Set CORS header")

--- a/test/grpc/server/interceptors/cors_test.exs
+++ b/test/grpc/server/interceptors/cors_test.exs
@@ -94,24 +94,6 @@ defmodule GRPC.Server.Interceptors.CORSTest do
     refute_received({:setting_headers, _headers}, "Set CORS headers during grpc")
   end
 
-  test "Default CORS allow origin header allows all" do
-    request = %FakeRequest{}
-    stream = Map.put(create_stream(), :access_mode, :grpcweb)
-
-    {:ok, :ok} =
-      CORSInterceptor.call(
-        request,
-        stream,
-        fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init(allow_origin: "*")
-      )
-
-    assert_received(
-      {:setting_headers, %{"access-control-allow-origin" => "*"}},
-      "Incorrect default header"
-    )
-  end
-
   test "CORS allow origin header value is configuraable with a static string" do
     request = %FakeRequest{}
     stream = Map.put(create_stream(), :access_mode, :grpcweb)
@@ -129,6 +111,14 @@ defmodule GRPC.Server.Interceptors.CORSTest do
       {:setting_headers, %{"access-control-allow-origin" => ^domain}},
       "Incorrect static header"
     )
+  end
+
+  test "CORS allow origin init does not accept non-string arguments" do
+    assert_raise(ArgumentError, fn -> CORSInterceptor.init(allow_origin: :atom) end)
+    assert_raise(ArgumentError, fn -> CORSInterceptor.init(allow_origin: 1) end)
+    assert_raise(ArgumentError, fn -> CORSInterceptor.init(allow_origin: 1.0) end)
+    assert_raise(ArgumentError, fn -> CORSInterceptor.init(allow_origin: []) end)
+    assert_raise(ArgumentError, fn -> CORSInterceptor.init(allow_origin: %{}) end)
   end
 
   test "CORS allow origin header value is configuraable with a two-arity function" do

--- a/test/support/test_adapter.exs
+++ b/test/support/test_adapter.exs
@@ -37,4 +37,9 @@ defmodule GRPC.Test.ServerAdapter do
   def has_sent_headers?(_stream) do
     false
   end
+
+  def set_headers(stream, headers) do
+    send(self(), {:setting_headers, headers})
+    stream
+  end
 end


### PR DESCRIPTION
This introduces:

* preflight request detection, allowing sensible responses to CORS preflight checks using the OPTIONS http verb
* client type detection, which may be one of grpc, grpcweb, or web (the latter implying a need for http transcoding)
* an interceptor that applies CORS headers for non-grpc requests

This is a draft for discussion in #237 