### PR TITLE
fix: passing the adapter_opts properly

### DIFF
--- a/lib/grpc/server/adapters/cowboy.ex
+++ b/lib/grpc/server/adapters/cowboy.ex
@@ -31,7 +31,7 @@ defmodule GRPC.Server.Adapters.Cowboy do
   @impl true
   def start(endpoint, servers, port, opts) do
     start_args = cowboy_start_args(endpoint, servers, port, opts)
-    start_func = if opts[:cred], do: :start_tls, else: :start_clear
+    start_func = if cred_opts(opts), do: :start_tls, else: :start_clear
 
     case apply(:cowboy, start_func, start_args) do
       {:ok, pid} ->
@@ -52,8 +52,10 @@ defmodule GRPC.Server.Adapters.Cowboy do
     [ref, trans_opts, proto_opts] = cowboy_start_args(endpoint, servers, port, opts)
     trans_opts = Map.put(trans_opts, :connection_type, :supervisor)
 
+    cred_opts = cred_opts(opts)
+
     {transport, protocol} =
-      if opts[:cred] do
+      if cred_opts do
         {:ranch_ssl, :cowboy_tls}
       else
         {:ranch_tcp, :cowboy_clear}
@@ -63,7 +65,7 @@ defmodule GRPC.Server.Adapters.Cowboy do
     # So we just support both child spec versions here instead
     case :ranch.child_spec(ref, transport, trans_opts, protocol, proto_opts) do
       {ref, mfa, type, timeout, kind, modules} ->
-        scheme = if opts[:cred], do: :https, else: :http
+        scheme = if cred_opts, do: :https, else: :http
         # Wrap real mfa to print starting log
         wrapped_mfa = {__MODULE__, :start_link, [scheme, endpoint, servers, mfa]}
 
@@ -226,12 +228,12 @@ defmodule GRPC.Server.Adapters.Cowboy do
     dispatch_key = Module.concat(endpoint, Dispatch)
     :persistent_term.put(dispatch_key, dispatch)
 
-    idle_timeout = Keyword.get(opts, :idle_timeout) || :infinity
-    num_acceptors = Keyword.get(opts, :num_acceptors) || @default_num_acceptors
-    max_connections = Keyword.get(opts, :max_connections) || @default_max_connections
+    idle_timeout = Keyword.get(adapter_opts, :idle_timeout) || :infinity
+    num_acceptors = Keyword.get(adapter_opts, :num_acceptors) || @default_num_acceptors
+    max_connections = Keyword.get(adapter_opts, :max_connections) || @default_max_connections
 
     # https://ninenines.eu/docs/en/cowboy/2.7/manual/cowboy_http2/
-    opts =
+    merged_adapter_opts =
       Map.merge(
         %{
           env: %{dispatch: {:persistent_term, dispatch_key}},
@@ -245,7 +247,7 @@ defmodule GRPC.Server.Adapters.Cowboy do
           max_received_frame_rate: {10_000_000, 10_000},
           max_reset_stream_rate: {10_000, 10_000}
         },
-        Enum.into(opts, %{})
+        Enum.into(adapter_opts, %{})
       )
 
     [
@@ -253,9 +255,9 @@ defmodule GRPC.Server.Adapters.Cowboy do
       %{
         num_acceptors: num_acceptors,
         max_connections: max_connections,
-        socket_opts: socket_opts(port, opts)
+        socket_opts: socket_opts(port, adapter_opts)
       },
-      opts
+      merged_adapter_opts
     ]
   end
 
@@ -270,8 +272,10 @@ defmodule GRPC.Server.Adapters.Cowboy do
         _, acc -> acc
       end)
 
-    if opts[:cred] do
-      opts[:cred].ssl ++
+    cred_opts = cred_opts(opts)
+
+    if cred_opts do
+      cred_opts.ssl ++
         [
           # These NPN/ALPN options are hardcoded in :cowboy.start_tls/3 (when calling start/3),
           # but not in :ranch.child_spec/5 (when calling child_spec/3). We must make sure they
@@ -283,6 +287,10 @@ defmodule GRPC.Server.Adapters.Cowboy do
     else
       socket_opts
     end
+  end
+
+  defp cred_opts(opts) do
+    Kernel.get_in(opts, [:cred]) || Kernel.get_in(opts, [:adapter_opts, :cred])
   end
 
   defp running_info(scheme, endpoint, servers, ref) do

--- a/lib/grpc/server/supervisor.ex
+++ b/lib/grpc/server/supervisor.ex
@@ -68,7 +68,7 @@ defmodule GRPC.Server.Supervisor do
 
         {:error, _} ->
           raise ArgumentError,
-                "just [:endpoint, :servers, :start_server, :port,] are accepted as arguments, and any other keys for adapters should be passed as adapter_opts!"
+                "just [:endpoint, :servers, :start_server, :port, :adapter_opts] are accepted as arguments, and any other keys for adapters should be passed as adapter_opts!"
       end
 
     endpoint_or_servers =

--- a/test/grpc/server/adapters/cowboy_test.exs
+++ b/test/grpc/server/adapters/cowboy_test.exs
@@ -7,11 +7,14 @@ defmodule GRPC.Server.Adapters.CowboyTest do
     test "produces the correct socket opts for ranch_tcp for inet" do
       spec =
         Cowboy.child_spec(:endpoint, [], 8080, [
-          {:foo, :bar},
-          {:ip, {127, 0, 0, 1}},
-          {:ipv6_v6only, false},
-          {:net, :inet},
-          {:baz, :foo}
+          {:adapter_opts,
+           [
+             {:foo, :bar},
+             {:ip, {127, 0, 0, 1}},
+             {:ipv6_v6only, false},
+             {:net, :inet},
+             {:baz, :foo}
+           ]}
         ])
 
       socket_opts = get_socket_opts_from_child_spec(spec)
@@ -23,11 +26,14 @@ defmodule GRPC.Server.Adapters.CowboyTest do
     test "produces the correct socket opts for ranch_tcp for inet6" do
       spec =
         Cowboy.child_spec(:endpoint, [], 8081, [
-          {:foo, :bar},
-          {:ip, {0, 0, 0, 0, 0, 0, 0, 1}},
-          {:ipv6_v6only, true},
-          {:net, :inet6},
-          {:baz, :foo}
+          {:adapter_opts,
+           [
+             {:foo, :bar},
+             {:ip, {0, 0, 0, 0, 0, 0, 0, 1}},
+             {:ipv6_v6only, true},
+             {:net, :inet6},
+             {:baz, :foo}
+           ]}
         ])
 
       socket_opts = get_socket_opts_from_child_spec(spec)


### PR DESCRIPTION
The `adapter_opts` keyword list encapsulates the :ip and :net options.