### PR TITLE
Always set CORS headers

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.15.7-otp-26
-erlang 26.1.2

--- a/lib/grpc/server/interceptors/cors.ex
+++ b/lib/grpc/server/interceptors/cors.ex
@@ -77,8 +77,7 @@ defmodule GRPC.Server.Interceptors.CORS do
 
   @impl true
   def call(req, stream, next, {allow_origin, allow_headers}) do
-    if stream.access_mode != :grpc and
-         Map.get(stream.http_request_headers, "sec-fetch-mode") == "cors" do
+    if stream.access_mode != :grpc do
       headers =
         %{}
         |> add_allowed_origins(req, stream, allow_origin)

--- a/test/grpc/server/interceptors/cors_test.exs
+++ b/test/grpc/server/interceptors/cors_test.exs
@@ -271,44 +271,4 @@ defmodule GRPC.Server.Interceptors.CORSTest do
       "Incorrect header when using function"
     )
   end
-
-  test "CORS only on cors sec-fetch-mode" do
-    request = %FakeRequest{}
-
-    stream = %{
-      create_stream()
-      | access_mode: :grpcweb,
-        http_request_headers: Map.put(@default_http_headers, "sec-fetch-mode", "same-origin")
-    }
-
-    {:ok, :ok} =
-      CORSInterceptor.call(
-        request,
-        %{stream | access_mode: :grpcweb},
-        fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init(allow_origin: "*")
-      )
-
-    refute_received({:setting_headers, _}, "Set CORS header")
-  end
-
-  test "No CORS if missing sec-fetch-mode header" do
-    request = %FakeRequest{}
-
-    stream = %{
-      create_stream()
-      | access_mode: :grpcweb,
-        http_request_headers: Map.delete(@default_http_headers, "sec-fetch-mode")
-    }
-
-    {:ok, :ok} =
-      CORSInterceptor.call(
-        request,
-        %{stream | access_mode: :grpcweb},
-        fn _request, _stream -> {:ok, :ok} end,
-        CORSInterceptor.init(allow_origin: "*")
-      )
-
-    refute_received({:setting_headers, _}, "Set CORS header")
-  end
 end


### PR DESCRIPTION
We have discovered that not all gRPC-web sessions advertise CORS in their headers, but they are still limited by CORS by the browser itself. This causes those non-advertising gRPC requests to fail unexpectedly. It is possible to trigger this with the official upstream JS library, even, depending on the configuration.

So this PR cuases the interceptor to always attempt to set CORS headers. In practice, this is still setting the headers just as often, as GRPC sessions that do advertise CORS in the request headers do so consistently, so the performance impact is essentially nil.