### PR TITLE
fix: update accepted_compressors to use channel's accepted_compressors

### DIFF
--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -309,7 +309,11 @@ defmodule GRPC.Stub do
       end
 
     compressor = Keyword.get(opts, :compressor, channel.compressor)
-    accepted_compressors = Keyword.get(opts, :accepted_compressors, [])
+    accepted_compressors = Keyword.get(opts, :accepted_compressors, channel.accepted_compressors)
+
+    if not is_list(accepted_compressors) do
+      raise ArgumentError, "accepted_compressors is not a list"
+    end
 
     accepted_compressors =
       if compressor do
@@ -321,7 +325,7 @@ defmodule GRPC.Stub do
     stream = %{
       stream
       | codec: Keyword.get(opts, :codec, channel.codec),
-        compressor: Keyword.get(opts, :compressor, channel.compressor),
+        compressor: compressor,
         accepted_compressors: accepted_compressors
     }
 


### PR DESCRIPTION
- Bug Fix: fallback to accepted compressors from the channel
- Bug Fix: do not allow non-list for accepted compressors in the stub call