### PR TITLE
refactor: better interface and simpler implementation for GRPC.Stream.run

### DIFF
--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -561,33 +561,24 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   end
 
   defp do_call_rpc(server, path, %{http_method: http_method} = stream) do
+    case server.__call_rpc__(path, http_method, stream) do
+      {:ok, stream, :noreply} ->
+        GRPC.Server.send_trailers(stream, @default_trailers)
+        {:ok, stream}
 
-    Process.put(GRPC.Stream, false)
-    result = server.__call_rpc__(path, http_method, stream)
-   case Process.get(GRPC.Stream) do
-    :unary ->
-      case result do
-        :ok ->
-          {:ok, stream}
-        error ->
-          error
-      end
-    _ ->
-      case result do
-        {:ok, stream, response} ->
-          stream
-          |> GRPC.Server.send_reply(response)
-          |> GRPC.Server.send_trailers(@default_trailers)
+      {:ok, stream, response} ->
+        stream
+        |> GRPC.Server.send_reply(response)
+        |> GRPC.Server.send_trailers(@default_trailers)
 
-          {:ok, stream}
+        {:ok, stream}
 
-        {:ok, stream} ->
-          GRPC.Server.send_trailers(stream, @default_trailers)
-          {:ok, stream}
+      {:ok, stream} ->
+        GRPC.Server.send_trailers(stream, @default_trailers)
+        {:ok, stream}
 
-        error ->
-          error
-      end
+      error ->
+        error
     end
   end
 

--- a/lib/grpc/server/stream.ex
+++ b/lib/grpc/server/stream.ex
@@ -89,14 +89,9 @@ defmodule GRPC.Server.Stream do
     do_send_reply(stream, codec.encode(response), opts)
   end
 
-  def send_reply(stream, :grpc_stream_noop, _opts) do
-    stream
-  end
-
   def send_reply(%{codec: codec} = stream, reply, opts) do
     do_send_reply(stream, codec.encode(reply), opts)
   end
-
 
   defp do_send_reply(
          %{adapter: adapter, codec: codec, access_mode: access_mode} = stream,

--- a/lib/grpc/stream.ex
+++ b/lib/grpc/stream.ex
@@ -143,9 +143,8 @@ defmodule GRPC.Stream do
   The `stream` argument must be initialized as a `:unary` stream with
   a `:materializer` set.
   """
-  @spec run(stream :: t()) :: :ok
+  @spec run(stream :: t()) :: :noreply
   def run(%__MODULE__{flow: flow, options: opts}) do
-    Process.put(__MODULE__, :unary)
     opts = Keyword.take(opts, [:unary, :materializer])
 
     if opts[:unary] != true do
@@ -155,13 +154,13 @@ defmodule GRPC.Stream do
     materializer = opts[:materializer]
 
     if is_nil(materializer) do
-      raise ArgumentError, "GRPC.Stream.run/1 requires a materializer to be set in the GRPC.Stream"
+      raise ArgumentError,
+            "GRPC.Stream.run/1 requires a materializer to be set in the GRPC.Stream"
     end
 
     send_response(materializer, Enum.at(flow, 0))
-    |> GRPC.Server.send_trailers(GRPC.Transport.HTTP2.server_trailers())
 
-    :ok
+    :noreply
   end
 
   @doc """
@@ -345,7 +344,8 @@ defmodule GRPC.Stream do
           :ok
 
         %GRPC.Server.Stream{} ->
-          raise ArgumentError, "materializer must be set to a unary GRPC.Server.Stream when unary: true is passed"
+          raise ArgumentError,
+                "materializer must be set to a unary GRPC.Server.Stream when unary: true is passed"
 
         _ ->
           raise ArgumentError, "materializer is required when unary: true is passed"

--- a/test/support/integration_test_case.ex
+++ b/test/support/integration_test_case.ex
@@ -16,7 +16,7 @@ defmodule GRPC.Integration.TestCase do
         start: {GRPC.Server, :start, [servers, port, opts]},
         type: :worker,
         restart: :permanent,
-        shutdown: 500,
+        shutdown: 500
       })
 
     try do
@@ -33,7 +33,7 @@ defmodule GRPC.Integration.TestCase do
         start: {GRPC.Server, :start_endpoint, [endpoint, port]},
         type: :worker,
         restart: :permanent,
-        shutdown: 500,
+        shutdown: 500
       })
 
     try do


### PR DESCRIPTION
- **fix: GRPC.Stream.run only consumes the first reply and returns :ok**
- **fix: simplify noreply workflow**
