### PR TITLE
fix: refresh error spam on direct_state (no lb)

### DIFF
--- a/lib/grpc/client/connection.ex
+++ b/lib/grpc/client/connection.ex
@@ -273,7 +273,8 @@ defmodule GRPC.Client.Connection do
         :refresh,
         %{lb_mod: lb_mod, lb_state: lb_state, real_channels: channels, virtual_channel: vc} =
           state
-      ) when not is_nil(lb_mod) do
+      )
+      when not is_nil(lb_mod) do
     {:ok, {prefer_host, prefer_port}, new_lb_state} = lb_mod.pick(lb_state)
 
     channel_key = "#{prefer_host}:#{prefer_port}"


### PR DESCRIPTION
Some context - even with the direct state where no lb_mod is picked the refresh is sent. This causes the lb_mod.pick on line 277 to crash, even though we don't use any loadbalancing