### PR TITLE
Report GRPC.Errors as normal shutdowns in the cowboy adapter

### DIFF
--- a/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/lib/grpc/server/adapters/cowboy/handler.ex
@@ -488,7 +488,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   end
 
   # expected error raised from user to return error immediately
-  def info({:EXIT, pid, {%RPCError{} = error, stacktrace}}, req, state = %{pid: pid}) do
+  def info({:EXIT, pid, {:shutdown, {%RPCError{} = error, stacktrace}}}, req, state = %{pid: pid}) do
     req = send_error(req, error, state, :rpc_error)
 
     [req: req]
@@ -550,7 +550,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
 
     case result do
       {:error, %GRPC.RPCError{} = e} ->
-        exit({e, _stacktrace = []})
+        exit({:shutdown, {e, _stacktrace = []}})
 
       {:error, %{kind: _kind, reason: _reason, stack: _stack} = e} ->
         exit({:handle_error, e})


### PR DESCRIPTION
This is a partial followup on https://github.com/elixir-grpc/grpc/issues/389#issuecomment-3465425788

The change to using `proc_lib` in this PR https://github.com/elixir-grpc/grpc/pull/381 results in SASL errors being reported when a GRPC server raises a `GRPC.Error`, which can get quite noisy. Given these are "expected" (quite explicitly in the code, even), the exit reason here should be `:shutdown` so that the SASL errors are not reported.

Since this already logs, I think suppressing these for the "expected" case makes sense.

Before:

```
19:31:49.429 [error] Process #PID<0.340.0> terminating
** (exit) {%GRPC.RPCError{status: 3, message: "invalid", details: nil}, []}
    (grpc 0.11.4) lib/grpc/server/adapters/cowboy/handler.ex:553: GRPC.Server.Adapters.Cowboy.Handler.call_rpc/3
    (stdlib 4.3.1.3) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Initial Call: GRPC.Server.Adapters.Cowboy.Handler.call_rpc/3
Ancestors: [#PID<0.339.0>, #PID<0.337.0>, #PID<0.296.0>, #PID<0.293.0>, #PID<0.292.0>, #PID<0.290.0>, #PID<0.289.0>, GRPCTest.Supervisor, #PID<0.287.0>]
Message Queue Length: 0
Messages: []
Links: [#PID<0.339.0>]
Dictionary: []
Trapping Exits: false
Status: :running
Heap Size: 376
Stack Size: 28
Reductions: 445

19:31:49.431 [error] ** (GRPC.Server.Adapters.ReportException) Exception raised while handling /helloworld.Greeter/SayHello:
** (GRPC.RPCError) invalid
```

After:
```
19:28:39.697 [error] ** (GRPC.Server.Adapters.ReportException) Exception raised while handling /helloworld.Greeter/SayHello:
** (GRPC.RPCError) invalid
```