### PR TITLE
Fix Connection state created by build_direct_state

### DIFF
--- a/grpc_client/lib/grpc/client/connection.ex
+++ b/grpc_client/lib/grpc/client/connection.ex
@@ -83,7 +83,7 @@ defmodule GRPC.Client.Connection do
 
   @type t :: %__MODULE__{
           virtual_channel: Channel.t(),
-          real_channels: %{String.t() => Channel.t()},
+          real_channels: %{String.t() => {:ok, Channel.t()} | {:error, any()}},
           lb_mod: module() | nil,
           lb_state: term() | nil,
           resolver: module() | nil,
@@ -446,7 +446,7 @@ defmodule GRPC.Client.Connection do
          %__MODULE__{
            base_state
            | virtual_channel: ch,
-             real_channels: %{"#{host}:#{port}" => ch}
+             real_channels: %{"#{host}:#{port}" => {:ok, ch}}
          }}
 
       {:error, reason} ->

--- a/grpc_client/test/grpc/channel_test.exs
+++ b/grpc_client/test/grpc/channel_test.exs
@@ -10,6 +10,8 @@ defmodule GRPC.ChannelTest do
           GRPC.Stub.connect("http://#{unquote(addr)}:50051", adapter: ClientAdapter)
 
         assert %Channel{host: unquote(addr), port: 50051, scheme: "http", cred: nil} = channel
+
+        assert {:ok, _} = GRPC.Stub.disconnect(channel)
       end
 
       test "errors if credential is provided" do
@@ -31,6 +33,8 @@ defmodule GRPC.ChannelTest do
         assert Keyword.has_key?(cred.ssl, :verify)
         assert Keyword.has_key?(cred.ssl, :depth)
         assert Keyword.has_key?(cred.ssl, :cacert_file)
+
+        assert {:ok, _} = GRPC.Stub.disconnect(channel)
       end
 
       test "allows overriding default credentials" do
@@ -40,6 +44,8 @@ defmodule GRPC.ChannelTest do
           GRPC.Stub.connect("https://#{unquote(addr)}:50051", adapter: ClientAdapter, cred: cred)
 
         assert %Channel{host: unquote(addr), port: 50051, scheme: "https", cred: ^cred} = channel
+
+        assert {:ok, _} = GRPC.Stub.disconnect(channel)
       end
     end
 
@@ -47,6 +53,8 @@ defmodule GRPC.ChannelTest do
       test "no cred uses http" do
         {:ok, channel} = GRPC.Stub.connect("#{unquote(addr)}:50051", adapter: ClientAdapter)
         assert %Channel{host: unquote(addr), port: 50051, scheme: "http", cred: nil} = channel
+
+        assert {:ok, _} = GRPC.Stub.disconnect(channel)
       end
 
       test "cred uses https" do
@@ -56,6 +64,8 @@ defmodule GRPC.ChannelTest do
           GRPC.Stub.connect("#{unquote(addr)}:50051", adapter: ClientAdapter, cred: cred)
 
         assert %Channel{host: unquote(addr), port: 50051, scheme: "https", cred: ^cred} = channel
+
+        assert {:ok, _} = GRPC.Stub.disconnect(channel)
       end
     end
   end
@@ -67,5 +77,7 @@ defmodule GRPC.ChannelTest do
       GRPC.Stub.connect("http://10.0.0.1:50051", adapter: ClientAdapter, headers: headers)
 
     assert %Channel{host: "10.0.0.1", port: 50051, headers: ^headers} = channel
+
+    assert {:ok, _} = GRPC.Stub.disconnect(channel)
   end
 end


### PR DESCRIPTION
`build_direct_state` was storing the channel in `real_channels` map instead of tuples like it is done in `build_real_channels`, causing connection refresh and disconnect to fail.