### PR TITLE
Fix typing of RPCError

### DIFF
--- a/grpc_core/lib/grpc/rpc_error.ex
+++ b/grpc_core/lib/grpc/rpc_error.ex
@@ -58,7 +58,7 @@ defmodule GRPC.RPCError do
   @type t :: %__MODULE__{
           status: GRPC.Status.t(),
           message: String.t(),
-          details: [Google.Protobuf.Any.t()]
+          details: [Google.Protobuf.Any.t()] | nil
         }
 
   alias GRPC.Status


### PR DESCRIPTION
Hello 👋🏼 

Just a quick fix to the typing of the `RPCError` struct. It appears to be expected that the `details` field will be `nil`, for example when calling `exception/2`. This makes Dialyzer happy for those who observe it.

❤️ 