### PR TITLE
support max_body_size in child spec options

### DIFF
--- a/grpc_server/lib/grpc/server/supervisor.ex
+++ b/grpc_server/lib/grpc/server/supervisor.ex
@@ -45,6 +45,7 @@ defmodule GRPC.Server.Supervisor do
       This function will be called with a `GRPC.Server.Adapters.ReportException` struct and must return a boolean
       indicating whether or not a given exception should be logged or dropped. Defaults to `nil`, which means all exceptions will be logged.
     * `:adapter_opts` - options for the adapter.
+    * `:max_body_size` - the maximum message body size to accept in bytes
 
   Either `:endpoint` or `:servers` must be present, but not both.
   """
@@ -71,14 +72,15 @@ defmodule GRPC.Server.Supervisor do
              :start_server,
              :port,
              :adapter_opts,
-             :exception_log_filter
+             :exception_log_filter,
+             :max_body_size
            ]) do
         {:ok, _opts} ->
           opts
 
         {:error, _} ->
           raise ArgumentError,
-                "just [:endpoint, :servers, :start_server, :port, :adapter_opts, :exception_log_filter] are accepted as arguments, and any other keys for adapters should be passed as adapter_opts!"
+                "just [:endpoint, :servers, :start_server, :port, :adapter_opts, :exception_log_filter, :max_body_size] are accepted as arguments, and any other keys for adapters should be passed as adapter_opts!"
       end
 
     case validate_cred(opts) do


### PR DESCRIPTION
With the new `max_body_size` support, body sizes can be controlled .. but the `max_body_size` parameter is not accepted as an option to the child spec of an endpoint.

We currently have this starting in a supervision tree:

```elixir
children = [
      GrpcReflection,
      {
        GRPC.Server.Supervisor,
        [
          endpoint: Ujs.Router.Endpoint,
          port: port,
          start_server: true,
          max_body_size: Application.get_env(:ujs, :grpc_server_max_body_size)
        ]
      }
    ]
```

This currently fails due to the missing `max_body_size`  key in the `Keyword.validate` call. This fixes that issue, and the above supervision tree starts and the max body size is correctly defined. 