### PR TITLE
fix(gun): map connection-level gun errors to internal status

### DIFF
--- a/grpc/lib/grpc/client/adapters/gun/stream_response_process.ex
+++ b/grpc/lib/grpc/client/adapters/gun/stream_response_process.ex
@@ -89,6 +89,11 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcess do
     |> push_message({:error, {:stream_error, reason}}, true)
   end
 
+  def handle_info({:gun_error, _conn_pid, reason}, state) do
+    state
+    |> push_message({:error, {:connection_error, reason}}, true)
+  end
+
   def handle_info({:connection_down, reason}, state) do
     push_message(state, {:error, {:connection_error, reason}}, true)
   end
@@ -96,6 +101,10 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcess do
   def handle_info(msg, state) do
     Logger.warning("#{inspect(__MODULE__)} received unexpected message: #{inspect(msg)}")
     push_message(state, {:error, {:unexpected_message, inspect(msg)}}, true)
+  end
+
+  defp push_message(%{done: true} = state, _message, _terminal?) do
+    {:noreply, state}
   end
 
   defp push_message(%{waiter: {from, timeout_ref}} = state, message, terminal?) do

--- a/grpc/test/grpc/adapters/gun/stream_response_process_test.exs
+++ b/grpc/test/grpc/adapters/gun/stream_response_process_test.exs
@@ -26,6 +26,44 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcessTest do
     assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 500
   end
 
+  test "maps connection-level gun errors to connection errors" do
+    {:ok, pid} = StreamResponseProcess.start_link()
+    monitor_ref = Process.monitor(pid)
+
+    reason = {:protocol_error, :"The preface was not received in a reasonable amount of time."}
+    send(pid, {:gun_error, self(), reason})
+
+    assert {:error, {:connection_error, ^reason}} = StreamResponseProcess.await(pid, 100)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 500
+  end
+
+  test "returns connection-level gun errors to an awaiting caller" do
+    {:ok, pid} = StreamResponseProcess.start_link()
+    monitor_ref = Process.monitor(pid)
+
+    task = Task.async(fn -> StreamResponseProcess.await(pid, 1_000) end)
+
+    waiter =
+      Enum.find_value(1..50, fn _ ->
+        case :sys.get_state(pid) do
+          %{waiter: nil} ->
+            Process.sleep(10)
+            nil
+
+          %{waiter: waiter} ->
+            waiter
+        end
+      end)
+
+    assert {_from, _timeout_ref} = waiter
+
+    reason = {:protocol_error, :"The preface was not received in a reasonable amount of time."}
+    send(pid, {:gun_error, self(), reason})
+
+    assert {:error, {:connection_error, ^reason}} = Task.await(task)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 500
+  end
+
   test "keeps queued shutdown errors after non-final headers" do
     {:ok, pid} = StreamResponseProcess.start_link()
     monitor_ref = Process.monitor(pid)
@@ -37,5 +75,27 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcessTest do
     assert {:error, {:connection_error, :shutdown}} = StreamResponseProcess.await(pid, 100)
     assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 500
     assert {:error, {:connection_error, :closed}} = StreamResponseProcess.await(pid, 100)
+  end
+
+  test "ignores connection errors after terminal trailers are already queued" do
+    {:ok, pid} = StreamResponseProcess.start_link()
+    monitor_ref = Process.monitor(pid)
+
+    send(pid, {:gun_trailers, self(), make_ref(), [{"grpc-status", "0"}]})
+    send(pid, {:connection_down, :shutdown})
+
+    assert {:trailers, [{"grpc-status", "0"}]} = StreamResponseProcess.await(pid, 100)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 500
+  end
+
+  test "ignores duplicate terminal connection errors" do
+    {:ok, pid} = StreamResponseProcess.start_link()
+    monitor_ref = Process.monitor(pid)
+
+    send(pid, {:connection_down, :first})
+    send(pid, {:connection_down, :second})
+
+    assert {:error, {:connection_error, :first}} = StreamResponseProcess.await(pid, 100)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 500
   end
 end

--- a/grpc/test/grpc/adapters/gun_test.exs
+++ b/grpc/test/grpc/adapters/gun_test.exs
@@ -122,4 +122,22 @@ defmodule GRPC.Client.Adapters.GunTest do
       assert %{conn_pid: nil} = disconnected_again.adapter_payload
     end
   end
+
+  describe "receive_data/2" do
+    test "maps connection-level gun errors to internal RPC errors" do
+      {:ok, response_pid} = GRPC.Client.Adapters.Gun.StreamResponseProcess.start_link()
+
+      reason = {:protocol_error, :"The preface was not received in a reasonable amount of time."}
+      send(response_pid, {:gun_error, self(), reason})
+
+      stream = %GRPC.Client.Stream{payload: %{response_pid: response_pid}, server_stream: false}
+      internal = GRPC.Status.internal()
+
+      assert {:error, %GRPC.RPCError{status: ^internal, message: message}} =
+               Gun.receive_data(stream, timeout: 100)
+
+      assert message =~ ":connection_error"
+      assert message =~ "preface"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The Gun adapter reports some connection errors as `GRPC.Status.unknown()`.

For example:

1. Gun receives an HTTP/2 connection error, e.g. a preface timeout.
2. Gun sends `{:gun_error, conn_pid, reason}` to the stream response process.
3. `StreamResponseProcess` treats it as an unexpected message.
4. The Gun adapter maps it to `GRPC.Status.unknown()` instead of a connection error.

`UNKNOWN` is the wrong status here because the adapter has already received a concrete Gun connection error. Exposing it as `UNKNOWN` loses that information and makes the failure look like an unexpected adapter message instead of a transport error. Userland code handling gRPC errors then only sees opaque status `2`, even though Gun reported a connection-level failure. In our case we decide if a request is retriable based on this, and would not want to broaden it to `UNKNOWN` unnecessarily.

## Root cause

`StreamResponseProcess` handles stream-level Gun errors with a stream ref:

```elixir
{:gun_error, conn_pid, stream_ref, reason}
```

but not connection-level Gun errors without a stream ref:

```elixir
{:gun_error, conn_pid, reason}
```

The connection-level message falls through to `unexpected_message`, even though Gun's own await helpers classify the same message as `connection_error`.

## Fix

Keep the fix scoped to the Gun adapter.

- Treat connection-level Gun errors as `{:connection_error, reason}`
- Keep stream-level Gun errors mapped as `{:stream_error, reason}`
- Ignore later terminal messages after the stream response process has already accepted a terminal message

With this change, connection-level Gun errors returned through `reply_to` map to `GRPC.Status.internal()` instead of `GRPC.Status.unknown()`.

## Test plan

- [x] Added regression test for connection-level Gun errors delivered before `await/2`
- [x] Added regression test for connection-level Gun errors delivered while `await/2` is waiting
- [x] Added adapter-level test that checks connection-level Gun errors become internal RPC errors
- [x] Added tests for duplicate terminal messages and terminal trailers followed by connection errors