### PR TITLE
fix(grpc): remove specs and enforce compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
             hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - name: Install Dependencies
         run: mix setup 1>/dev/null
+      - name: Compile with warnings as errors
+        run: MIX_ENV=test mix compile --warnings-as-errors
       - name: Run Tests
         run: mix test --warnings-as-errors
       - name: Run Warning Tests

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ defmodule HelloworldStreams.Server do
   alias Helloworld.HelloRequest
   alias Helloworld.HelloReply
 
-  @spec say_unary_hello(HelloRequest.t(), GRPC.Server.Stream.t()) :: any()
   def say_unary_hello(request, materializer) do
     request
     |> GRPC.Stream.unary(materializer: materializer)
@@ -136,7 +135,6 @@ end
 ### Bidirectional Streaming
 
 ```elixir
-@spec say_bid_stream_hello(Enumerable.t(), GRPC.Server.Stream.t()) :: any()
 def say_bid_stream_hello(request, materializer) do
   output_stream =
     Stream.repeatedly(fn ->

--- a/grpc/lib/grpc/client/adapters/gun/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/gun/connection_process.ex
@@ -20,8 +20,6 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
   require Logger
   alias GRPC.Client.Adapters.Gun.StreamResponseProcess
 
-  @spec connect(GRPC.Channel.t(), map()) ::
-          {:ok, %{conn_pid: pid()}} | {:error, any()}
   def connect(channel, open_opts) when is_map(open_opts) do
     case DynamicSupervisor.start_child(GRPC.Client.Supervisor, child_spec(channel, open_opts)) do
       {:ok, connection_process_pid} ->
@@ -35,7 +33,6 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
     end
   end
 
-  @spec disconnect(pid()) :: :ok
   def disconnect(connection_process_pid) when is_pid(connection_process_pid) do
     GenServer.call(connection_process_pid, :disconnect)
   catch
@@ -43,24 +40,18 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
       :ok
   end
 
-  @spec request(pid(), iodata(), list(), iodata()) ::
-          {:ok, %{stream_ref: reference(), response_pid: pid()}} | {:error, any()}
   def request(connection_process_pid, path, headers, body) do
     GenServer.call(connection_process_pid, {:request, path, headers, body})
   end
 
-  @spec open_stream(pid(), iodata(), list()) ::
-          {:ok, %{stream_ref: reference(), response_pid: pid()}} | {:error, any()}
   def open_stream(connection_process_pid, path, headers) do
     GenServer.call(connection_process_pid, {:open_stream, path, headers})
   end
 
-  @spec send_data(pid(), reference(), :fin | :nofin, iodata()) :: :ok
   def send_data(connection_process_pid, stream_ref, fin, data) do
     GenServer.call(connection_process_pid, {:send_data, stream_ref, fin, data})
   end
 
-  @spec cancel(pid(), reference()) :: :ok
   def cancel(connection_process_pid, stream_ref) do
     GenServer.call(connection_process_pid, {:cancel, stream_ref})
   end
@@ -75,7 +66,6 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
     }
   end
 
-  @spec start_link(GRPC.Channel.t(), map()) :: GenServer.on_start()
   def start_link(channel, open_opts) do
     if is_nil(channel.ref) do
       GenServer.start_link(__MODULE__, {channel, open_opts})

--- a/grpc/lib/grpc/client/adapters/gun/stream_response_process.ex
+++ b/grpc/lib/grpc/client/adapters/gun/stream_response_process.ex
@@ -22,12 +22,10 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcess do
           done: boolean()
         }
 
-  @spec start_link() :: GenServer.on_start()
   def start_link do
     GenServer.start_link(__MODULE__, [])
   end
 
-  @spec await(pid(), timeout()) :: tuple()
   def await(pid, timeout) do
     GenServer.call(pid, {:await, timeout}, :infinity)
   catch
@@ -110,7 +108,7 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcess do
   defp push_message(%{waiter: {from, timeout_ref}} = state, message, terminal?) do
     cancel_timeout(timeout_ref)
     GenServer.reply(from, message)
-    new_state = %{state | waiter: nil, done: state.done or terminal?}
+    new_state = %{state | waiter: nil, done: terminal?}
 
     if terminal? do
       {:stop, :normal, new_state}
@@ -120,7 +118,7 @@ defmodule GRPC.Client.Adapters.Gun.StreamResponseProcess do
   end
 
   defp push_message(%{messages: messages} = state, message, terminal?) do
-    {:noreply, %{state | messages: :queue.in(message, messages), done: state.done or terminal?}}
+    {:noreply, %{state | messages: :queue.in(message, messages), done: terminal?}}
   end
 
   defp terminal?(:fin), do: true

--- a/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -19,8 +19,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
     @doc """
     Starts and link connection process
     """
-    @spec start_link(Mint.Types.scheme(), Mint.Types.address(), :inet.port_number(), keyword()) ::
-            GenServer.on_start()
     def start_link(scheme, host, port, opts \\ []) do
       opts = Keyword.put(opts, :parent, self())
       GenServer.start_link(__MODULE__, {scheme, host, port, opts})
@@ -33,14 +31,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
 
       * :stream_response_pid (required) - the process to where send the responses coming from the connection will be sent to be processed
     """
-    @spec request(
-            pid :: pid(),
-            method :: String.t(),
-            path :: String.t(),
-            Mint.Types.headers(),
-            body :: iodata() | nil | :stream,
-            opts :: keyword()
-          ) :: {:ok, %{request_ref: Mint.Types.request_ref()}} | {:error, Mint.Types.error()}
     def request(pid, method, path, headers, body, opts \\ []) do
       GenServer.call(pid, {:request, method, path, headers, body, opts})
     end
@@ -48,7 +38,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
     @doc """
     Closes the given connection.
     """
-    @spec disconnect(pid :: pid()) :: :ok
     def disconnect(pid) do
       GenServer.call(pid, :disconnect)
     end
@@ -56,11 +45,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
     @doc """
     Streams a chunk of the request body on the connection or signals the end of the body.
     """
-    @spec stream_request_body(
-            pid(),
-            Mint.Types.request_ref(),
-            iodata() | :eof | {:eof, trailing_headers :: Mint.Types.headers()}
-          ) :: :ok | {:error, Mint.Types.error()}
     def stream_request_body(pid, request_ref, body) do
       GenServer.call(pid, {:stream_body, request_ref, body})
     end
@@ -68,7 +52,6 @@ if Code.ensure_loaded?(Mint.HTTP) do
     @doc """
     cancels an open request request
     """
-    @spec cancel(pid(), Mint.Types.request_ref()) :: :ok | {:error, Mint.Types.error()}
     def cancel(pid, request_ref) do
       GenServer.call(pid, {:cancel_request, request_ref})
     end

--- a/grpc/lib/grpc/client/adapters/mint/stream_response_process.ex
+++ b/grpc/lib/grpc/client/adapters/mint/stream_response_process.ex
@@ -18,16 +18,11 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
   # TODO: Refactor the GenServer.call/3 occurrences on this module to produce
   # telemetry events and log entries in case of failures
 
-  @typep accepted_types :: :data | :trailers | :headers | :error
-  @typep data_types :: binary() | Mint.Types.headers() | Mint.Types.error()
-
   @accepted_types [:data, :trailers, :headers, :error]
   @header_types [:headers, :trailers]
 
   use GenServer
 
-  @spec start_link(GRPC.Client.Stream.t(), send_headers_or_trailers? :: boolean()) ::
-          GenServer.on_start()
   def start_link(stream, send_headers_or_trailers?) do
     GenServer.start_link(__MODULE__, {stream, send_headers_or_trailers?})
   end
@@ -36,7 +31,6 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
   Given a pid from this process, build an Elixir.Stream that will consume the accumulated
   data inside this process
   """
-  @spec build_stream(pid(), produce_trailers? :: boolean) :: Enumerable.t()
   def build_stream(pid, produce_trailers? \\ true) do
     Stream.unfold(pid, fn pid ->
       pid
@@ -62,7 +56,6 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
     once all messages are produced. This process will automatically
     be killed.
   """
-  @spec done(pid()) :: :ok
   def done(pid) do
     :ok = GenServer.call(pid, {:consume_response, :done})
     :ok
@@ -71,7 +64,6 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
   @doc """
   Consume an incoming data or trailers/headers
   """
-  @spec consume(pid(), type :: accepted_types, data :: data_types) :: :ok
   def consume(pid, type, data) when type in @accepted_types do
     :ok = GenServer.call(pid, {:consume_response, {type, data}})
     :ok

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -179,7 +179,6 @@ defmodule GRPC.Client.Connection do
       iex> {:ok, ch} = GRPC.Client.Connection.connect("127.0.0.1:50051")
       iex> Grpc.Testing.TestService.Stub.empty_call(ch, %{})
   """
-  @spec connect(String.t(), keyword()) :: {:ok, Channel.t()} | {:error, any()}
   def connect(target, opts \\ []) do
     case build_initial_state(target, opts) do
       {:ok, initial_state} ->
@@ -215,7 +214,6 @@ defmodule GRPC.Client.Connection do
       iex> GRPC.Client.Connection.disconnect(ch)
       {:ok, %GRPC.Channel{}}
   """
-  @spec disconnect(Channel.t()) :: {:ok, Channel.t()} | {:error, any()}
   def disconnect(%Channel{ref: ref} = channel) do
     GenServer.call(via(ref), {:disconnect, channel})
   end
@@ -238,7 +236,6 @@ defmodule GRPC.Client.Connection do
       iex> GRPC.Client.Connection.pick(ch)
       {:ok, %GRPC.Channel{host: "192.168.1.1", port: 50051}}
   """
-  @spec pick_channel(Channel.t(), keyword()) :: {:ok, Channel.t()} | {:error, term()}
   def pick_channel(%Channel{ref: ref} = _channel, _opts \\ []) do
     case :persistent_term.get({__MODULE__, ref}, nil) do
       {lb_mod, lb_state} when not is_nil(lb_mod) ->
@@ -258,7 +255,6 @@ defmodule GRPC.Client.Connection do
   Intended for use by health checks or heartbeat mechanisms that detect
   a backend has gone away and want to force a fresh DNS lookup.
   """
-  @spec resolve_now(Channel.t()) :: :ok
   def resolve_now(%Channel{ref: ref}) do
     GenServer.cast(via(ref), :resolve_now)
   end

--- a/grpc/lib/grpc/client/connection/endpoint_resolver.ex
+++ b/grpc/lib/grpc/client/connection/endpoint_resolver.ex
@@ -41,8 +41,6 @@ defmodule GRPC.Client.Connection.EndpointResolver do
       {"ipv6:::1:50051", "http", nil}
 
   """
-  @spec normalize(String.t(), GRPC.Credential.t() | nil) ::
-          {String.t(), String.t(), GRPC.Credential.t() | nil}
   def normalize(target, cred)
       when is_binary(target) and (is_nil(cred) or is_struct(cred, GRPC.Credential)) do
     uri = URI.parse(target)
@@ -105,7 +103,6 @@ defmodule GRPC.Client.Connection.EndpointResolver do
       {"myhost", 50051}
 
   """
-  @spec split_host_port(String.t()) :: {String.t(), pos_integer()}
   def split_host_port(target) when is_binary(target) do
     cond do
       String.contains?(target, "[") ->

--- a/grpc/lib/grpc/client/resolver.ex
+++ b/grpc/lib/grpc/client/resolver.ex
@@ -113,9 +113,6 @@ defmodule GRPC.Client.Resolver do
 
   This function abstracts the resolution mechanism, allowing the gRPC client to obtain endpoints and service configuration regardless of the underlying target type.
   """
-  @spec resolve(String.t()) ::
-          {:ok, %{addresses: list(map()), service_config: GRPC.Client.ServiceConfig.t()}}
-          | {:error, term()}
   def resolve(target) do
     uri = URI.parse(target)
     scheme = uri.scheme || "dns"

--- a/grpc/lib/grpc/client/stream.ex
+++ b/grpc/lib/grpc/client/stream.ex
@@ -71,7 +71,6 @@ defmodule GRPC.Client.Stream do
   end
 
   @doc false
-  @spec send_request(GRPC.Client.Stream.t(), struct, Keyword.t()) :: GRPC.Client.Stream.t()
   def send_request(
         %{codec: codec, channel: %{adapter: adapter}, compressor: compressor} = stream,
         request,

--- a/grpc/lib/grpc/stub.ex
+++ b/grpc/lib/grpc/stub.ex
@@ -240,17 +240,11 @@ defmodule GRPC.Stub do
 
   * When using DNS or xDS targets, the connection layer periodically refreshes endpoints.
   """
-  @spec connect(String.t(), keyword()) :: {:ok, Channel.t()} | {:error, any()}
   def connect(addr, opts \\ []) when is_binary(addr) and is_list(opts) do
     Connection.connect(addr, opts)
   end
 
   @deprecated "Use connect/2 instead"
-  @spec connect(
-          String.t() | {:local, String.t()},
-          binary() | non_neg_integer(),
-          keyword()
-        ) :: {:ok, Channel.t()} | {:error, any()}
   def connect(host, port, opts) when is_binary(port) do
     connect(host, String.to_integer(port), opts)
   end
@@ -275,7 +269,6 @@ defmodule GRPC.Stub do
   @doc """
   Disconnects the adapter and frees any resources the adapter is consuming
   """
-  @spec disconnect(Channel.t()) :: {:ok, Channel.t()} | {:error, any()}
   def disconnect(%Channel{} = channel) do
     Connection.disconnect(channel)
   end
@@ -404,7 +397,6 @@ defmodule GRPC.Stub do
     * `:end_stream` - indicates it's the last one request, then the stream will be in
       half_closed state. Default is false.
   """
-  @spec send_request(GRPC.Client.Stream.t(), struct, keyword()) :: GRPC.Client.Stream.t()
   def send_request(%{__interface__: interface} = stream, request, opts \\ []) do
     interface[:send_request].(stream, request, opts)
   end
@@ -419,7 +411,6 @@ defmodule GRPC.Stub do
       iex> stream = GRPC.Stub.send_request(stream, request)
       iex> GRPC.Stub.end_stream(stream)
   """
-  @spec end_stream(GRPC.Client.Stream.t()) :: GRPC.Client.Stream.t()
   def end_stream(%{channel: channel} = stream) do
     channel.adapter.end_stream(stream)
   end
@@ -479,12 +470,6 @@ defmodule GRPC.Stub do
       iex> ex_stream |> Enum.to_list()
       []
   """
-  @spec recv(GRPC.Client.Stream.t(), keyword()) ::
-          {:ok, struct()}
-          | {:ok, struct(), map()}
-          | {:ok, Enumerable.t()}
-          | {:ok, Enumerable.t(), map()}
-          | {:error, any()}
   def recv(stream, opts \\ [])
 
   def recv(%{canceled: true}, _) do

--- a/grpc_core/lib/grpc/google/rpc.ex
+++ b/grpc_core/lib/grpc/google/rpc.ex
@@ -1,14 +1,12 @@
 defmodule GRPC.Google.RPC do
   @moduledoc false
 
-  @spec encode_status(Google.Rpc.Status.t()) :: String.t()
   def encode_status(%Google.Rpc.Status{} = status) do
     status
     |> Google.Rpc.Status.encode()
     |> Base.encode64(padding: true)
   end
 
-  @spec decode_status(String.t()) :: {:ok, Google.Rpc.Status.t()} | {:error, term()}
   def decode_status(encoded_details_bin) when is_binary(encoded_details_bin) do
     {:ok,
      encoded_details_bin

--- a/grpc_core/lib/grpc/message.ex
+++ b/grpc_core/lib/grpc/message.ex
@@ -41,8 +41,6 @@ defmodule GRPC.Message do
       {:error, "Encoded message is too large (9 bytes)"}
 
   """
-  @spec to_data(iodata, keyword()) ::
-          {:ok, iodata, non_neg_integer} | {:error, String.t()}
   def to_data(message, opts \\ []) do
     compressor = opts[:compressor]
     iolist = opts[:iolist]
@@ -83,7 +81,6 @@ defmodule GRPC.Message do
       iex> GRPC.Message.from_data(<<0, 0, 0, 0, 8, 1, 2, 3, 4, 5, 6, 7, 8>>)
       {<<1, 2, 3, 4, 5, 6, 7, 8>>, <<>>}
   """
-  @spec from_data(binary) :: {message :: binary, rest :: binary}
   def from_data(data) do
     <<_flag::unsigned-integer-size(8), length::big-32, message::bytes-size(length), rest::binary>> =
       data
@@ -99,10 +96,6 @@ defmodule GRPC.Message do
       iex> GRPC.Message.from_data(%{compressor: nil}, <<0, 0, 0, 0, 8, 1, 2, 3, 4, 5, 6, 7, 8>>)
       {:ok, <<1, 2, 3, 4, 5, 6, 7, 8>>, <<>>}
   """
-  @spec from_data(map, binary) ::
-          {:ok, message :: binary, rest :: binary}
-          | {:trailers, map, rest :: binary}
-          | {:error, GRPC.RPCError.t()}
   def from_data(%{compressor: nil}, data) do
     case data do
       <<0, length::big-32, message::bytes-size(length), rest::binary>> ->

--- a/grpc_core/lib/grpc/rpc_error.ex
+++ b/grpc_core/lib/grpc/rpc_error.ex
@@ -63,12 +63,10 @@ defmodule GRPC.RPCError do
 
   alias GRPC.Status
 
-  @spec new(status :: atom()) :: t()
   def new(status) when is_atom(status) do
     exception(status: status)
   end
 
-  @spec exception(args :: list()) :: t()
   def exception(args) when is_list(args) do
     error = parse_args(args, %__MODULE__{})
 
@@ -101,7 +99,6 @@ defmodule GRPC.RPCError do
     parse_args(t, acc)
   end
 
-  @spec exception(status :: Status.t() | atom(), message :: String.t()) :: t()
   def exception(status, message) when is_atom(status) do
     %GRPC.RPCError{status: apply(GRPC.Status, status, []), message: message}
   end

--- a/grpc_core/lib/grpc/status.ex
+++ b/grpc_core/lib/grpc/status.ex
@@ -30,13 +30,11 @@ defmodule GRPC.Status do
   @doc """
   Not an error; returned on success.
   """
-  @spec ok :: t
   def ok, do: 0
 
   @doc """
   The operation was cancelled (typically by the caller).
   """
-  @spec cancelled() :: t()
   def cancelled, do: 1
 
   @doc """
@@ -48,7 +46,6 @@ defmodule GRPC.Status do
   errors raised by APIs that do not return enough error information
   may be converted to this error.
   """
-  @spec unknown :: t
   def unknown, do: 2
 
   @doc """
@@ -58,7 +55,6 @@ defmodule GRPC.Status do
   INVALID_ARGUMENT indicates arguments that are problematic regardless of
   the state of the system (e.g., a malformed file name).
   """
-  @spec invalid_argument :: t
   def invalid_argument, do: 3
 
   @doc """
@@ -69,19 +65,16 @@ defmodule GRPC.Status do
   successful response from a server could have been delayed long
   enough for the deadline to expire.
   """
-  @spec deadline_exceeded :: t
   def deadline_exceeded, do: 4
 
   @doc """
   Some requested entity (e.g., file or directory) was not found.
   """
-  @spec not_found :: t
   def not_found, do: 5
 
   @doc """
   Some entity that we attempted to create (e.g., file or directory) already exists.
   """
-  @spec already_exists :: t
   def already_exists, do: 6
 
   @doc """
@@ -94,14 +87,12 @@ defmodule GRPC.Status do
   used if the caller can not be identified (use UNAUTHENTICATED
   instead for those errors).
   """
-  @spec permission_denied :: t
   def permission_denied, do: 7
 
   @doc """
   Some resource has been exhausted, perhaps a per-user quota, or
   perhaps the entire file system is out of space.
   """
-  @spec resource_exhausted :: t
   def resource_exhausted, do: 8
 
   @doc """
@@ -111,7 +102,6 @@ defmodule GRPC.Status do
   For example, directory to be deleted may be non-empty,
   an rmdir operation is applied to a non-directory, etc.
   """
-  @spec failed_precondition :: t
   def failed_precondition, do: 9
 
   @doc """
@@ -120,7 +110,6 @@ defmodule GRPC.Status do
   Typically due to a concurrency issue like sequencer check failures,
   transaction aborts, etc.
   """
-  @spec aborted() :: t()
   def aborted, do: 10
 
   @doc """
@@ -128,13 +117,11 @@ defmodule GRPC.Status do
 
   E.g., seeking or reading past end of file.
   """
-  @spec out_of_range :: t
   def out_of_range, do: 11
 
   @doc """
   Operation is not implemented or not supported/enabled in this service.
   """
-  @spec unimplemented :: t
   def unimplemented, do: 12
 
   @doc """
@@ -143,7 +130,6 @@ defmodule GRPC.Status do
   Means some invariants expected by underlying system has been broken.
   If you see one of these errors, something is very broken.
   """
-  @spec internal :: t
   def internal, do: 13
 
   @doc """
@@ -152,22 +138,18 @@ defmodule GRPC.Status do
   This is a most likely a transient condition and may be corrected by retrying with
   a backoff.
   """
-  @spec unavailable :: t
   def unavailable, do: 14
 
   @doc """
   Unrecoverable data loss or corruption.
   """
-  @spec data_loss :: t
   def data_loss, do: 15
 
   @doc """
   The request does not have valid authentication credentials for the operation.
   """
-  @spec unauthenticated :: t
   def unauthenticated, do: 16
 
-  @spec code_name(t()) :: binary()
   def code_name(0), do: "OK"
   def code_name(1), do: "Canceled"
   def code_name(2), do: "Unknown"
@@ -186,7 +168,6 @@ defmodule GRPC.Status do
   def code_name(15), do: "DataLoss"
   def code_name(16), do: "Unauthenticated"
 
-  @spec http_code(t()) :: t()
   def http_code(0), do: 200
   def http_code(1), do: 400
   def http_code(2), do: 500
@@ -205,7 +186,6 @@ defmodule GRPC.Status do
   def http_code(15), do: 500
   def http_code(16), do: 401
 
-  @spec status_message(t()) :: String.t() | nil
   def status_message(0), do: nil
   def status_message(1), do: "The operation was cancelled (typically by the caller)"
   def status_message(2), do: "Unknown error"

--- a/grpc_core/lib/grpc/transport/http2.ex
+++ b/grpc_core/lib/grpc/transport/http2.ex
@@ -18,7 +18,6 @@ defmodule GRPC.Transport.HTTP2 do
     %{"content-type" => "application/grpc+#{codec_name(codec)}"}
   end
 
-  @spec server_trailers(integer, String.t(), [Google.Protobuf.Any.t()] | nil) :: map
   def server_trailers(status \\ Status.ok(), message \\ "", details \\ nil) do
     %{
       "grpc-status" => Integer.to_string(status),
@@ -44,7 +43,6 @@ defmodule GRPC.Transport.HTTP2 do
   @doc """
   Now we may not need this because gun already handles the pseudo headers.
   """
-  @spec client_headers(GRPC.Client.Stream.t(), keyword()) :: [{String.t(), String.t()}]
   def client_headers(%{channel: channel, path: path} = s, opts \\ []) do
     [
       {":method", "POST"},
@@ -54,9 +52,6 @@ defmodule GRPC.Transport.HTTP2 do
     ] ++ client_headers_without_reserved(s, opts)
   end
 
-  @spec client_headers_without_reserved(GRPC.Client.Stream.t(), keyword()) :: [
-          {String.t(), String.t()}
-        ]
   def client_headers_without_reserved(%{codec: codec} = stream, opts \\ []) do
     [
       # It seems only gRPC implemenations only support "application/grpc", so we support :content_type now.

--- a/grpc_core/lib/grpc/transport/utils.ex
+++ b/grpc_core/lib/grpc/transport/utils.ex
@@ -45,7 +45,6 @@ defmodule GRPC.Transport.Utils do
     to_string(div(timeout, 1000 * 3600)) <> "H"
   end
 
-  @spec decode_timeout(String.t()) :: non_neg_integer()
   def decode_timeout(timeout) do
     {timeout, unit} = String.split_at(timeout, -1)
     decode_timeout(unit, String.to_integer(timeout))

--- a/grpc_server/README.md
+++ b/grpc_server/README.md
@@ -96,7 +96,6 @@ defmodule HelloworldStreams.Server do
   alias Helloworld.HelloRequest
   alias Helloworld.HelloReply
 
-  @spec say_unary_hello(HelloRequest.t(), GRPC.Server.Stream.t()) :: any()
   def say_unary_hello(request, materializer) do
     request
     |> GRPC.Stream.unary(materializer: materializer)
@@ -125,7 +124,6 @@ end
 ### Bidirectional Streaming
 
 ```elixir
-@spec say_bid_stream_hello(Enumerable.t(), GRPC.Server.Stream.t()) :: any()
 def say_bid_stream_hello(request, materializer) do
   output_stream =
     Stream.repeatedly(fn ->

--- a/grpc_server/lib/grpc/protoc/cli.ex
+++ b/grpc_server/lib/grpc/protoc/cli.ex
@@ -22,7 +22,6 @@ defmodule GRPC.Protoc.CLI do
 
   # Entrypoint for the escript (protoc-gen-elixir).
   @doc false
-  @spec main([String.t()]) :: :ok
   def main(args)
 
   def main(["--version"]) do
@@ -135,8 +134,6 @@ defmodule GRPC.Protoc.CLI do
 
   # Made public for testing.
   @doc false
-  @spec find_types(Context.t(), [Google.Protobuf.FileDescriptorProto.t()], [String.t()]) ::
-          Context.t()
   def find_types(%Context{} = ctx, descs, files_to_generate)
       when is_list(descs) and is_list(files_to_generate) do
     global_type_mapping =

--- a/grpc_server/lib/grpc/protoc/generator.ex
+++ b/grpc_server/lib/grpc/protoc/generator.ex
@@ -4,8 +4,6 @@ defmodule GRPC.Protoc.Generator do
   alias Protobuf.Protoc.Context
   alias Protobuf.Protoc.Generator
 
-  @spec generate(Context.t(), %Google.Protobuf.FileDescriptorProto{}) ::
-          [Google.Protobuf.Compiler.CodeGeneratorResponse.File.t()]
   def generate(%Context{} = ctx, %Google.Protobuf.FileDescriptorProto{} = desc) do
     module_definitions =
       ctx

--- a/grpc_server/lib/grpc/protoc/generator/service.ex
+++ b/grpc_server/lib/grpc/protoc/generator/service.ex
@@ -13,8 +13,6 @@ defmodule GRPC.Protoc.Generator.Service do
     [:assigns]
   )
 
-  @spec generate(Context.t(), Google.Protobuf.ServiceDescriptorProto.t()) ::
-          {String.t(), String.t()}
   def generate(%Context{} = ctx, %Google.Protobuf.ServiceDescriptorProto{} = desc) do
     # service can't be nested
     mod_name = Util.mod_name(ctx, [Macro.camelize(desc.name)])

--- a/grpc_server/lib/grpc/server.ex
+++ b/grpc_server/lib/grpc/server.ex
@@ -232,8 +232,6 @@ defmodule GRPC.Server do
   end
 
   @doc false
-  @spec call(atom(), GRPC.Server.Stream.t(), tuple(), atom()) ::
-          {:ok, GRPC.Server.Stream.t(), struct()} | {:ok, struct()}
   def call(
         _service_mod,
         stream,
@@ -420,8 +418,6 @@ defmodule GRPC.Server do
   #     * `:status_handler` - adds a status handler that could be listening on HTTP/1, if necessary.
   #                           It should follow the format defined by cowboy_router:compile/3
   @doc false
-  @spec start(module() | [module()], non_neg_integer(), Keyword.t()) ::
-          {atom(), any(), non_neg_integer()} | {:error, any()}
   def start(servers, port, opts \\ []) do
     adapter = Keyword.get(opts, :adapter) || GRPC.Server.Adapters.Cowboy
     servers = GRPC.Server.servers_to_map(servers)
@@ -429,8 +425,6 @@ defmodule GRPC.Server do
   end
 
   @doc false
-  @spec start_endpoint(atom(), non_neg_integer(), Keyword.t()) ::
-          {atom(), any(), non_neg_integer()}
   def start_endpoint(endpoint, port, opts \\ []) do
     opts =
       Keyword.validate!(opts,
@@ -456,7 +450,6 @@ defmodule GRPC.Server do
   #
   #   * `:adapter` - use a custom adapter instead of default `GRPC.Server.Adapters.Cowboy`
   @doc false
-  @spec stop(module() | [module()], Keyword.t()) :: any()
   def stop(servers, opts \\ []) do
     opts = Keyword.validate!(opts, adapter: GRPC.Server.Adapters.Cowboy)
     adapter = opts[:adapter]
@@ -465,7 +458,6 @@ defmodule GRPC.Server do
   end
 
   @doc false
-  @spec stop_endpoint(atom(), Keyword.t()) :: any()
   def stop_endpoint(endpoint, opts \\ []) do
     opts = Keyword.validate!(opts, adapter: GRPC.Server.Adapters.Cowboy)
     adapter = opts[:adapter]
@@ -481,7 +473,6 @@ defmodule GRPC.Server do
 
       iex> GRPC.Server.send_reply(stream, reply)
   """
-  @spec send_reply(GRPC.Server.Stream.t(), struct()) :: GRPC.Server.Stream.t()
   def send_reply(
         %{__interface__: interface} = stream,
         reply,
@@ -495,7 +486,6 @@ defmodule GRPC.Server do
 
   You can send headers only once, before that you can set headers using `set_headers/2`.
   """
-  @spec send_headers(GRPC.Server.Stream.t(), map()) :: GRPC.Server.Stream.t()
   def send_headers(%{adapter: adapter} = stream, headers) do
     adapter.send_headers(stream.payload, headers)
     stream
@@ -506,7 +496,6 @@ defmodule GRPC.Server do
 
   You can set headers more than once.
   """
-  @spec set_headers(GRPC.Server.Stream.t(), map()) :: GRPC.Server.Stream.t()
   def set_headers(%{adapter: adapter} = stream, headers) do
     adapter.set_headers(stream.payload, headers)
     stream
@@ -515,7 +504,6 @@ defmodule GRPC.Server do
   @doc """
   Set custom trailers, which will be sent in the end.
   """
-  @spec set_trailers(GRPC.Server.Stream.t(), map()) :: GRPC.Server.Stream.t()
   def set_trailers(%{adapter: adapter} = stream, trailers) do
     adapter.set_resp_trailers(stream.payload, trailers)
     stream
@@ -525,7 +513,6 @@ defmodule GRPC.Server do
   Set compressor to compress responses. An accepted compressor will be set if clients use one,
   even if `set_compressor` is not called. But this can be called to override the chosen.
   """
-  @spec set_compressor(GRPC.Server.Stream.t(), module()) :: GRPC.Server.Stream.t()
   def set_compressor(%{adapter: adapter} = stream, compressor) do
     adapter.set_compressor(stream.payload, compressor)
     stream
@@ -538,7 +525,6 @@ defmodule GRPC.Server do
   end
 
   @doc false
-  @spec servers_to_map(module() | [module()]) :: %{String.t() => [module()]}
   def servers_to_map(servers) do
     Enum.reduce(List.wrap(servers), %{}, fn s, acc ->
       Map.put(acc, s.__meta__(:service).__meta__(:name), s)

--- a/grpc_server/lib/grpc/server/adapters/cowboy.ex
+++ b/grpc_server/lib/grpc/server/adapters/cowboy.ex
@@ -48,8 +48,6 @@ defmodule GRPC.Server.Adapters.Cowboy do
   @doc """
   Return a child_spec to start server. See `GRPC.Server.Adapters.Cowboy.start/4` for a list of supported options.
   """
-  @spec child_spec(atom(), %{String.t() => [module()]}, non_neg_integer(), Keyword.t()) ::
-          Supervisor.child_spec()
   def child_spec(endpoint, servers, port, opts) do
     [ref, trans_opts, proto_opts] = cowboy_start_args(endpoint, servers, port, opts)
     trans_opts = Map.put(trans_opts, :connection_type, :supervisor)
@@ -86,8 +84,6 @@ defmodule GRPC.Server.Adapters.Cowboy do
   end
 
   # spec: :supervisor.mfargs doesn't work
-  @spec start_link(atom(), atom(), %{String.t() => [module()]}, any()) ::
-          {:ok, pid()} | {:error, any()}
   def start_link(scheme, endpoint, servers, {m, f, [ref | _] = a}) do
     case apply(m, f, a) do
       {:ok, pid} ->
@@ -112,12 +108,10 @@ defmodule GRPC.Server.Adapters.Cowboy do
     :cowboy.stop_listener(servers_name(endpoint, servers))
   end
 
-  @spec read_body(GRPC.Server.Adapter.state()) :: {:ok, binary()}
   def read_body(%{pid: pid}) do
     Handler.read_full_body(pid)
   end
 
-  @spec reading_stream(GRPC.Server.Adapter.state()) :: Enumerable.t()
   def reading_stream(%{pid: pid}) do
     Stream.unfold(%{pid: pid, need_more: true, buffer: <<>>}, fn acc -> read_stream(acc) end)
   end

--- a/grpc_server/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/grpc_server/lib/grpc/server/adapters/cowboy/handler.ex
@@ -57,7 +57,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   which is the point where we call the functions implemented by users (aka the modules who use
   the `GRPC.Server` macro)
   """
-  @spec init(:cowboy_req.req(), state :: init_state) :: init_result
   def init(req, {endpoint, {_name, server}, route, opts} = state) do
     http_method = extract_http_method(req)
     exception_log_filter = extract_exception_log_filter_opt(opts)
@@ -221,7 +220,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   Synchronously reads the whole body content of a given request.
   Raise in case of a timeout.
   """
-  @spec read_full_body(stream_pid :: pid) :: binary()
   def read_full_body(pid) do
     sync_call(pid, :read_full_body)
   end
@@ -230,7 +228,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   Synchronously reads a chunk of body content of a given request.
   Raise in case of a timeout.
   """
-  @spec read_body(stream_pid :: pid) :: binary()
   def read_body(pid) do
     sync_call(pid, :read_body)
   end
@@ -239,13 +236,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   Asynchronously send back to client a chunk of `data`, when `http_transcode?` is true, the
   data is sent back as it's, with no transformation of protobuf binaries to http2 data frames.
   """
-  @spec stream_body(
-          stream_pid :: pid,
-          data :: iodata,
-          opts :: list(stream_body_opts),
-          is_fin,
-          http_transcode? :: boolean()
-        ) :: :ok
   def stream_body(pid, data, opts, is_fin, http_transcode? \\ false) do
     send(pid, {:stream_body, data, opts, is_fin, http_transcode?})
     :ok
@@ -254,7 +244,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   @doc """
   Asynchronously send back to the client the http status and the headers for a given request.
   """
-  @spec stream_reply(stream_pid :: pid, status :: non_neg_integer(), headers :: headers) :: :ok
   def stream_reply(pid, status, headers) do
     send(pid, {:stream_reply, status, headers})
     :ok
@@ -264,7 +253,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   Asynchronously set the headers for a given request. This function does not send any
   data back to the client. It simply appends the headers to be used in the response.
   """
-  @spec set_resp_headers(stream_pid :: pid, headers :: headers) :: :ok
   def set_resp_headers(pid, headers) do
     send(pid, {:set_resp_headers, headers})
     :ok
@@ -274,7 +262,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   Asynchronously set the trailer headers for a given request. This function does not send any
   data back to the client. It simply appends the trailer headers to be used in the response.
   """
-  @spec set_resp_trailers(stream_pid :: pid, trailers :: headers) :: :ok
   def set_resp_trailers(pid, trailers) do
     send(pid, {:set_resp_trailers, trailers})
     :ok
@@ -285,7 +272,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   the `grpc-accept-encoding` header is present on the original request, otherwise no compression
   is applied.
   """
-  @spec set_compressor(stream_pid :: pid, compressor :: module) :: :ok
   def set_compressor(pid, compressor) do
     send(pid, {:set_compressor, compressor})
     :ok
@@ -294,7 +280,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   @doc """
   Asynchronously stream the given trailers of request back to client.
   """
-  @spec stream_trailers(stream_pid :: pid, trailers :: headers) :: :ok
   def stream_trailers(pid, trailers) do
     send(pid, {:stream_trailers, trailers})
     :ok
@@ -303,7 +288,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   @doc """
   Return all request headers.
   """
-  @spec get_headers(stream_pid :: pid) :: :cowboy.http_headers()
   def get_headers(pid) do
     sync_call(pid, :get_headers)
   end
@@ -311,7 +295,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   @doc """
   Return the peer IP address and port number
   """
-  @spec get_peer(stream_pid :: pid) :: {:inet.ip_address(), :inet.port_number()}
   def get_peer(pid) do
     sync_call(pid, :get_peer)
   end
@@ -320,7 +303,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   Return the client TLS certificate. `:undefined` is returned if no certificate was specified
   when establishing the connection.
   """
-  @spec get_cert(stream_pid :: pid) :: binary() | :undefined
   def get_cert(pid) do
     sync_call(pid, :get_cert)
   end
@@ -328,7 +310,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   @doc """
   Return the query string for the request URI.
   """
-  @spec get_qs(stream_pid :: pid) :: binary()
   def get_qs(pid) do
     sync_call(pid, :get_qs)
   end
@@ -336,7 +317,6 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   @doc """
   Return all bindings of a given request.
   """
-  @spec get_bindings(stream_pid :: pid) :: :cowboy_router.bindings()
   def get_bindings(pid) do
     sync_call(pid, :get_bindings)
   end

--- a/grpc_server/lib/grpc/server/router.ex
+++ b/grpc_server/lib/grpc/server/router.ex
@@ -8,7 +8,6 @@ defmodule GRPC.Server.Router do
 
   @wildcards [:_, :__]
 
-  @spec build_route(binary() | map()) :: route()
   def build_route(path) when is_binary(path), do: build_route(:post, path)
   def build_route(%{pattern: {method, path}}), do: build_route(method, path)
 
@@ -24,7 +23,6 @@ defmodule GRPC.Server.Router do
       {:get, path, match} = GRPC.Server.Router.build_route(:get, "/v1/{book.location=shelves/*}/books/{book.name=*}")
       {true, %{"book.location": "shelves/example-shelf", "book.name": "example-book"}} = GRPC.Server.Router.match("/v1/shelves/example-shelf/books/example-book", match, [])
   """
-  @spec build_route(atom(), binary()) :: route()
   def build_route(method, path) when is_binary(path) do
     match =
       path
@@ -41,7 +39,6 @@ defmodule GRPC.Server.Router do
 
        ["v1", "messages"] = GRPC.Server.Router.split_path("/v1/messages")
   """
-  @spec split_path(String.t()) :: iolist()
   def split_path(bin) do
     for segment <- String.split(bin, "/"), segment != "", do: segment
   end
@@ -63,12 +60,10 @@ defmodule GRPC.Server.Router do
       false = GRPC.Server.Router.match("/v1/shelves/example-shelf/something-els/books/book", match)
 
   """
-  @spec match(String.t() | [String.t()], Template.matchers()) :: {true, map()} | false
   def match(path, match) do
     match(path, match, %{})
   end
 
-  @spec match(String.t() | [String.t()], Template.matchers(), map()) :: {true, map()} | false
   def match(path, match, bindings) when is_binary(path) do
     path
     |> split_path()

--- a/grpc_server/lib/grpc/server/router/field_path.ex
+++ b/grpc_server/lib/grpc/server/router/field_path.ex
@@ -1,7 +1,6 @@
 defmodule GRPC.Server.Router.FieldPath do
   @moduledoc false
 
-  @spec decode_pair({binary(), term()}, map()) :: map()
   def decode_pair({key, value}, acc) do
     parts = :binary.split(key, ".", [:global])
     assign_map(parts, value, acc)

--- a/grpc_server/lib/grpc/server/router/query.ex
+++ b/grpc_server/lib/grpc/server/router/query.ex
@@ -10,7 +10,6 @@ defmodule GRPC.Server.Router.Query do
 
   alias GRPC.Server.Router.FieldPath
 
-  @spec decode(String.t(), map()) :: %{optional(String.t()) => term()}
   def decode(query, acc \\ %{})
 
   def decode("", acc) do

--- a/grpc_server/lib/grpc/server/router/template.ex
+++ b/grpc_server/lib/grpc/server/router/template.ex
@@ -10,7 +10,6 @@ defmodule GRPC.Server.Router.Template do
   @type segment_match :: String.t() | {atom(), [segment_match]}
   @type matchers :: [segment_match]
 
-  @spec tokenize(binary(), [tuple()]) :: [tuple()]
   def tokenize(path, tokens \\ [])
 
   def tokenize(<<>>, tokens) do
@@ -40,7 +39,6 @@ defmodule GRPC.Server.Router.Template do
     {{:identifier, acc, []}, <<>>}
   end
 
-  @spec parse(tokens :: [tuple()], matchers()) :: matchers() | {matchers, tokens :: [tuple()]}
   def parse([], matchers) do
     Enum.reverse(matchers)
   end

--- a/grpc_server/lib/grpc/server/stream.ex
+++ b/grpc_server/lib/grpc/server/stream.ex
@@ -118,7 +118,6 @@ defmodule GRPC.Server.Stream do
   Milliseconds left before the inbound deadline, or `:infinity` if the caller set none.
   Clamped at 0 so an already-expired deadline never returns a negative value.
   """
-  @spec remaining_ms(t()) :: non_neg_integer() | :infinity
   def remaining_ms(%__MODULE__{deadline: nil}), do: :infinity
 
   def remaining_ms(%__MODULE__{deadline: deadline}),

--- a/grpc_server/lib/grpc/server/supervisor.ex
+++ b/grpc_server/lib/grpc/server/supervisor.ex
@@ -49,8 +49,6 @@ defmodule GRPC.Server.Supervisor do
 
   Either `:endpoint` or `:servers` must be present, but not both.
   """
-  @spec init(tuple()) :: no_return
-  @spec init(keyword()) :: {:ok, {sup_flags(), [Supervisor.child_spec()]}} | :ignore
   def init(opts)
 
   def init(opts) when is_tuple(opts) do
@@ -126,8 +124,6 @@ defmodule GRPC.Server.Supervisor do
       If present, has more precedence then the `config :gprc, :start_server`
       config value (i.e. `start_server: false` will not start the server in any case).
   """
-  @spec child_spec(endpoint_or_servers :: atom() | [atom()], port :: integer, opts :: keyword()) ::
-          Supervisor.Spec.spec()
   def child_spec(endpoint_or_servers, port, opts \\ [])
 
   def child_spec(endpoint, port, opts) when is_atom(endpoint) do

--- a/grpc_server/lib/grpc/server/transcode.ex
+++ b/grpc_server/lib/grpc/server/transcode.ex
@@ -11,8 +11,6 @@ defmodule GRPC.Server.Transcode do
   # 3. All other fields are passed via the URL query parameters, and the parameter name is the field path in the request message. A repeated field can be represented as multiple query parameters under the same name.
   # If HttpRule.body is "*", there is no URL query parameter, all fields are passed via URL path and HTTP request body.
   # If HttpRule.body is omitted, there is no HTTP request body, all fields are passed via URL path and URL query parameters.
-  @spec map_request(t(), map(), map(), String.t(), module()) ::
-          {:ok, struct()} | {:error, term()}
   def map_request(
         %{body: ""},
         _body_request,
@@ -65,7 +63,6 @@ defmodule GRPC.Server.Transcode do
   defp map_request_body(%{body: field}, request_body),
     do: %{field => request_body}
 
-  @spec map_response_body(t() | map(), map()) :: map()
   def map_response_body(%{response_body: ""}, response_body), do: response_body
 
   def map_response_body(%{response_body: field}, response_body) do
@@ -73,7 +70,6 @@ defmodule GRPC.Server.Transcode do
     Map.get(response_body, key)
   end
 
-  @spec map_path_bindings(map()) :: map()
   def map_path_bindings(bindings) when bindings == %{}, do: bindings
 
   def map_path_bindings(bindings) do

--- a/grpc_server/lib/grpc/stream.ex
+++ b/grpc_server/lib/grpc/stream.ex
@@ -84,7 +84,6 @@ defmodule GRPC.Stream do
       flow = GRPC.Stream.from(request, max_demand: 50)
   """
   @doc type: :creation
-  @spec from(any(), Keyword.t()) :: t()
   def from(input, opts \\ [])
 
   def from(%Elixir.Stream{} = input, opts), do: build_grpc_stream(input, opts)
@@ -120,7 +119,6 @@ defmodule GRPC.Stream do
       flow = GRPC.Stream.unary(request, max_demand: 5)
   """
   @doc type: :creation
-  @spec unary(any(), Keyword.t()) :: t()
   def unary(input, opts \\ []) when is_struct(input),
     do: build_grpc_stream([input], Keyword.merge(opts, unary: true))
 
@@ -134,7 +132,6 @@ defmodule GRPC.Stream do
     A `Flow` pipeline.
   """
   @doc type: :transforms
-  @spec to_flow(t()) :: Flow.t()
   def to_flow(%__MODULE__{flow: flow}) when is_nil(flow), do: Flow.from_enumerable([])
 
   def to_flow(%__MODULE__{flow: flow}), do: flow
@@ -164,7 +161,6 @@ defmodule GRPC.Stream do
       end
   """
   @doc type: :materialization
-  @spec run(stream :: t()) :: :noreply
   def run(%__MODULE__{flow: flow, options: opts}) do
     opts = Keyword.take(opts, [:unary, :materializer])
 
@@ -220,7 +216,6 @@ defmodule GRPC.Stream do
       end
   """
   @doc type: :materialization
-  @spec run_with(t(), Stream.t(), Keyword.t()) :: :ok
   def run_with(
         %__MODULE__{flow: flow, options: flow_opts} = _stream,
         %Materializer{} = from,
@@ -293,7 +288,6 @@ defmodule GRPC.Stream do
   enabling seamless continuation of the pipeline.
   """
   @doc type: :actions
-  @spec effect(t(), (term -> any)) :: t()
   defdelegate effect(stream, effect_fun), to: Operators
 
   @doc """
@@ -312,7 +306,6 @@ defmodule GRPC.Stream do
 
   """
   @doc type: :actions
-  @spec ask(t(), pid | atom, non_neg_integer) :: t() | {:error, :timeout | :process_not_alive}
   defdelegate ask(stream, target, timeout \\ 5000), to: Operators
 
   @doc """
@@ -324,7 +317,6 @@ defmodule GRPC.Stream do
   Prefer `ask/3` for production usage unless failure should abort the stream.
   """
   @doc type: :actions
-  @spec ask!(t(), pid | atom, non_neg_integer) :: t()
   defdelegate ask!(stream, target, timeout \\ 5000), to: Operators
 
   @doc """
@@ -332,7 +324,6 @@ defmodule GRPC.Stream do
 
   The filter function is applied concurrently to the stream entries, so it shouldn't rely on execution order.
   """
-  @spec filter(t(), (term -> term)) :: t
   @doc type: :transforms
   defdelegate filter(stream, filter), to: Operators
 
@@ -342,14 +333,12 @@ defmodule GRPC.Stream do
   Useful for emitting multiple messages for each input.
   """
   @doc type: :transforms
-  @spec flat_map(t, (term -> Enumerable.t())) :: t()
   defdelegate flat_map(stream, flat_mapper), to: Operators
 
   @doc """
   Applies a function to each stream item.
   """
   @doc type: :transforms
-  @spec map(t(), (term -> term)) :: t()
   defdelegate map(stream, mapper), to: Operators
 
   @doc """
@@ -416,7 +405,6 @@ defmodule GRPC.Stream do
   This is useful for operations that require access to the stream's headers.
   """
   @doc type: :transforms
-  @spec map_with_context(t(), (map(), term -> term)) :: t()
   defdelegate map_with_context(stream, mapper), to: Operators
 
   @doc """
@@ -432,7 +420,6 @@ defmodule GRPC.Stream do
 
   """
   @doc type: :transforms
-  @spec partition(t(), keyword()) :: t()
   defdelegate partition(stream, options \\ []), to: Operators
 
   @doc """
@@ -448,7 +435,6 @@ defmodule GRPC.Stream do
 
   """
   @doc type: :transforms
-  @spec reduce(t, (-> acc), (term(), acc -> acc)) :: t when acc: term()
   defdelegate reduce(stream, acc_fun, reducer_fun), to: Operators
 
   @doc """
@@ -456,7 +442,6 @@ defmodule GRPC.Stream do
 
   """
   @doc type: :transforms
-  @spec uniq(t) :: t
   defdelegate uniq(stream), to: Operators
 
   @doc """
@@ -467,7 +452,6 @@ defmodule GRPC.Stream do
 
   """
   @doc type: :transforms
-  @spec uniq_by(t, (term -> term)) :: t
   defdelegate uniq_by(stream, fun), to: Operators
 
   @doc """
@@ -477,7 +461,6 @@ defmodule GRPC.Stream do
 
   To receive headers on the client side, use the `:return_headers` option. See `GRPC.Stub`.
   """
-  @spec get_headers(GRPC.Server.Stream.t()) :: map
   def get_headers(%GRPC.Server.Stream{adapter: adapter} = stream) do
     headers = adapter.get_headers(stream.payload)
     GRPC.Transport.HTTP2.decode_headers(headers)

--- a/grpc_server/lib/grpc/stream/operators.ex
+++ b/grpc_server/lib/grpc/stream/operators.ex
@@ -8,14 +8,11 @@ defmodule GRPC.Stream.Operators do
 
   @type reason :: any()
 
-  @spec ask(GRPCStream.t(), pid | atom, non_neg_integer) ::
-          GRPCStream.t() | {:error, :timeout | :process_not_alive}
   def ask(%GRPCStream{flow: flow} = stream, target, timeout \\ 5000) do
     mapper = fn item -> safe_invoke(&do_ask(&1, target, timeout, raise_on_error: false), item) end
     %GRPCStream{stream | flow: Flow.map(flow, mapper)}
   end
 
-  @spec ask!(GRPCStream.t(), pid | atom, non_neg_integer) :: GRPCStream.t()
   def ask!(%GRPCStream{flow: flow} = stream, target, timeout \\ 5000) do
     mapper = fn item -> do_ask(item, target, timeout, raise_on_error: true) end
     %GRPCStream{stream | flow: Flow.map(flow, mapper)}
@@ -51,7 +48,6 @@ defmodule GRPC.Stream.Operators do
     end
   end
 
-  @spec effect(GRPCStream.t(), (term -> term())) :: GRPCStream.t()
   def effect(%GRPCStream{flow: flow} = stream, effect_fun) when is_function(effect_fun, 1) do
     flow =
       Flow.map(flow, fn flow_item ->
@@ -61,13 +57,11 @@ defmodule GRPC.Stream.Operators do
     %GRPCStream{stream | flow: flow}
   end
 
-  @spec filter(GRPCStream.t(), (term -> term)) :: GRPCStream.t()
   def filter(%GRPCStream{flow: flow} = stream, filter) do
     flow_wrapper = Flow.filter(flow, fn item -> safe_invoke(filter, item) end)
     %GRPCStream{stream | flow: flow_wrapper}
   end
 
-  @spec flat_map(GRPCStream.t(), (term -> Enumerable.GRPCStream.t())) :: GRPCStream.t()
   def flat_map(%GRPCStream{flow: flow} = stream, flat_mapper) do
     flow_wrapper =
       Flow.flat_map(flow, fn item ->
@@ -80,13 +74,11 @@ defmodule GRPC.Stream.Operators do
     %GRPCStream{stream | flow: flow_wrapper}
   end
 
-  @spec map(GRPCStream.t(), (term -> term)) :: GRPCStream.t()
   def map(%GRPCStream{flow: flow} = stream, mapper) do
     flow_wrapper = Flow.map(flow, fn item -> safe_invoke(mapper, item) end)
     %GRPCStream{stream | flow: flow_wrapper}
   end
 
-  @spec map_with_context(GRPCStream.t(), (map(), term -> term)) :: GRPCStream.t()
   def map_with_context(%GRPCStream{flow: flow, metadata: meta} = stream, mapper)
       when is_function(mapper, 2) do
     wrapper = fn item ->
@@ -98,7 +90,6 @@ defmodule GRPC.Stream.Operators do
     %GRPCStream{stream | flow: flow_wrapper}
   end
 
-  @spec map_error(GRPCStream.t(), (reason -> term)) :: GRPCStream.t()
   def map_error(%GRPCStream{flow: flow} = stream, func) when is_function(func, 1) do
     mapper =
       Flow.map(flow, fn
@@ -126,28 +117,23 @@ defmodule GRPC.Stream.Operators do
     end
   end
 
-  @spec partition(GRPCStream.t(), keyword()) :: GRPCStream.t()
   def partition(%GRPCStream{flow: flow} = stream, options \\ []) do
     %GRPCStream{stream | flow: Flow.partition(flow, options)}
   end
 
-  @spec reduce(GRPCStream.t(), (-> acc), (term, acc -> acc)) :: GRPCStream.t() when acc: term()
   def reduce(%GRPCStream{flow: flow} = stream, acc_fun, reducer_fun) do
     %GRPCStream{stream | flow: Flow.reduce(flow, acc_fun, reducer_fun)}
   end
 
-  @spec reject(GRPCStream.t(), (term -> term)) :: GRPCStream.t()
   def reject(%GRPCStream{flow: flow} = stream, filter) do
     flow_wrapper = Flow.reject(flow, fn item -> safe_invoke(filter, item) end)
     %GRPCStream{stream | flow: flow_wrapper}
   end
 
-  @spec uniq(GRPCStream.t()) :: GRPCStream.t()
   def uniq(%GRPCStream{flow: flow} = stream) do
     %GRPCStream{stream | flow: Flow.uniq(flow)}
   end
 
-  @spec uniq_by(GRPCStream.t(), (term -> term)) :: GRPCStream.t()
   def uniq_by(%GRPCStream{flow: flow} = stream, fun) do
     %GRPCStream{stream | flow: Flow.uniq_by(flow, fun)}
   end


### PR DESCRIPTION
## Problem

Dialyzer reports `GRPC.Stub.connect/2` as returning a value outside its own spec.

`connect/2` returns a `GRPC.Channel` struct, but `GRPC.Channel.t()` is stricter than the channel states built by the client connection code. In our project, running dialyzer errors on calls to `connect/2` which sees a broken public type:

```text
::warning file=lib/grpc/client/connection.ex,line=190,title=call::The function call finalize_connection will not succeed.
::warning file=lib/grpc/client/connection.ex,line=193,title=call::The function call finalize_connection will not succeed.
::warning file=lib/grpc/client/connection.ex,line=354,title=no_return::Function finalize_connection/2 has no local return.
::warning file=lib/grpc/client/connection.ex,line=355,title=call::The function call pick_channel will not succeed.
```

`GRPC.Client.Stream.t()` has the same issue for fields that start as `nil` and are filled later.

## Root cause

The `Channel` and `Stream` structs support incrementally populating their values, but the public types describe only fully populated state.


## Fix

[Project direction](https://github.com/elixir-grpc/grpc/pull/551#issuecomment-4859531775) is to stop supporting Dialyzer and instead leverage Elixir compiler warnings:
- Remove explicit `@spec` annotations from source and README examples
- Compile with warnings as errors in CI
- Keep tests running with warnings as errors in CI
- Fix the Gun stream response state update that Elixir 1.20 flags under warnings as errors

## Review attention

Elixir's type system did not catch the issue related to stream trailer parsing flagged by Dialyzer, so I'm deferring that to a future PR to avoid conflating things:
> ::warning file=lib/grpc/client/adapters/gun.ex,line=435,title=guard_fail::The guard clause can never succeed.

## Test plan

- [x] Pulled in `grpc` and `grpc_core` from this branch in our project and successfully ran dialyzer
