### PR TITLE
fix: make GRPC.Stub generation opt-out for server-only protoc runs

### DIFF
--- a/grpc_server/lib/grpc/protoc/cli.ex
+++ b/grpc_server/lib/grpc/protoc/cli.ex
@@ -20,6 +20,8 @@ defmodule GRPC.Protoc.CLI do
 
   alias Protobuf.Protoc.Context
 
+  @gen_stubs_disabled_plugin "__grpc_server_gen_stubs_disabled__"
+
   # Entrypoint for the escript (protoc-gen-elixir).
   @doc false
   def main(args)
@@ -74,6 +76,11 @@ defmodule GRPC.Protoc.CLI do
     Google.Protobuf.Compiler.CodeGeneratorResponse.Feature.value(:FEATURE_PROTO3_OPTIONAL)
   end
 
+  @doc false
+  def gen_stubs?(%Context{plugins: plugins}) do
+    @gen_stubs_disabled_plugin not in plugins
+  end
+
   # Made public for testing.
   @doc false
   def parse_params(%Context{} = ctx, params_str) when is_binary(params_str) do
@@ -83,7 +90,16 @@ defmodule GRPC.Protoc.CLI do
   end
 
   defp parse_param("plugins=" <> plugins, %Context{} = ctx) do
-    %Context{ctx | plugins: String.split(plugins, "+")}
+    plugins = String.split(plugins, "+")
+
+    plugins =
+      if gen_stubs?(ctx) do
+        plugins
+      else
+        [@gen_stubs_disabled_plugin | plugins]
+      end
+
+    %Context{ctx | plugins: plugins}
   end
 
   defp parse_param("gen_descriptors=" <> value, %Context{} = ctx) do
@@ -93,6 +109,19 @@ defmodule GRPC.Protoc.CLI do
 
       other ->
         raise "invalid value for gen_descriptors option, expected \"true\", got: #{inspect(other)}"
+    end
+  end
+
+  defp parse_param("gen_stubs=" <> value, %Context{} = ctx) do
+    case value do
+      "true" ->
+        put_gen_stubs(ctx, true)
+
+      "false" ->
+        put_gen_stubs(ctx, false)
+
+      other ->
+        raise "invalid value for gen_stubs option, expected \"true\" or \"false\", got: #{inspect(other)}"
     end
   end
 
@@ -130,6 +159,19 @@ defmodule GRPC.Protoc.CLI do
 
   defp parse_param(_unknown, %Context{} = ctx) do
     ctx
+  end
+
+  defp put_gen_stubs(%Context{} = ctx, true) do
+    %Context{ctx | plugins: List.delete(ctx.plugins, @gen_stubs_disabled_plugin)}
+  end
+
+  defp put_gen_stubs(%Context{} = ctx, false) do
+    plugins =
+      ctx.plugins
+      |> List.delete(@gen_stubs_disabled_plugin)
+      |> then(&[@gen_stubs_disabled_plugin | &1])
+
+    %Context{ctx | plugins: plugins}
   end
 
   # Made public for testing.

--- a/grpc_server/lib/grpc/protoc/generator/service.ex
+++ b/grpc_server/lib/grpc/protoc/generator/service.ex
@@ -34,6 +34,7 @@ defmodule GRPC.Protoc.Generator.Service do
          methods: methods,
          descriptor_fun_body: descriptor_fun_body,
          version: Util.version(),
+         gen_stubs?: GRPC.Protoc.CLI.gen_stubs?(ctx),
          module_doc?: false
        )
      )}

--- a/grpc_server/priv/templates/service.ex.eex
+++ b/grpc_server/priv/templates/service.ex.eex
@@ -16,9 +16,11 @@ defmodule <%= @module %>.Service do
   <% end %>
 end
 
+<%= if @gen_stubs? do %>
 defmodule <%= @module %>.Stub do
   <%= unless @module_doc? do %>
   @moduledoc false
   <% end %>
   use GRPC.Stub, service: <%= @module %>.Service
 end
+<% end %>

--- a/grpc_server/test/grpc/protoc/generator/service_test.exs
+++ b/grpc_server/test/grpc/protoc/generator/service_test.exs
@@ -1,0 +1,67 @@
+defmodule GRPC.Protoc.Generator.ServiceTest do
+  use ExUnit.Case, async: true
+
+  alias GRPC.Protoc.CLI
+  alias GRPC.Protoc.Generator.Service
+  alias Protobuf.Protoc.Context
+
+  describe "generate/2" do
+    test "generates service and stub modules by default" do
+      {_module, content} = Service.generate(context(), service())
+
+      assert content =~ "defmodule Helloworld.Greeter.Service do"
+      assert content =~ "defmodule Helloworld.Greeter.Stub do"
+      assert content =~ "use GRPC.Stub, service: Helloworld.Greeter.Service"
+    end
+
+    test "generates service module without stub when gen_stubs=false" do
+      ctx = CLI.parse_params(context(), "gen_stubs=false")
+
+      {_module, content} = Service.generate(ctx, service())
+
+      assert content =~ "defmodule Helloworld.Greeter.Service do"
+      refute content =~ "defmodule Helloworld.Greeter.Stub do"
+      refute content =~ "use GRPC.Stub"
+    end
+  end
+
+  describe "parse_params/2" do
+    test "accepts gen_stubs=true and gen_stubs=false" do
+      assert CLI.gen_stubs?(CLI.parse_params(context(), "gen_stubs=true"))
+      refute CLI.gen_stubs?(CLI.parse_params(context(), "gen_stubs=false"))
+      refute CLI.gen_stubs?(CLI.parse_params(context(), "gen_stubs=false,plugins=grpc"))
+    end
+
+    test "raises on invalid gen_stubs values" do
+      assert_raise RuntimeError,
+                   ~s(invalid value for gen_stubs option, expected "true" or "false", got: "maybe"),
+                   fn ->
+                     CLI.parse_params(context(), "gen_stubs=maybe")
+                   end
+    end
+  end
+
+  defp context do
+    %Context{
+      package: "helloworld",
+      dep_type_mapping: %{
+        ".helloworld.HelloRequest" => %{type_name: "Helloworld.HelloRequest"},
+        ".helloworld.HelloReply" => %{type_name: "Helloworld.HelloReply"}
+      }
+    }
+  end
+
+  defp service do
+    %Google.Protobuf.ServiceDescriptorProto{
+      name: "Greeter",
+      method: [
+        %Google.Protobuf.MethodDescriptorProto{
+          name: "SayHello",
+          input_type: ".helloworld.HelloRequest",
+          output_type: ".helloworld.HelloReply",
+          options: %Google.Protobuf.MethodOptions{}
+        }
+      ]
+    }
+  end
+end


### PR DESCRIPTION
## Summary

`protoc-gen-elixir` (the gRPC generator) now supports opting out of `GRPC.Stub` client generation for server-only runs. A new `gen_stubs=false` option skips emitting the client stub module while still generating the service module, so projects that only implement servers no longer carry unused client stubs.

## Why this matters

Issue #549 asks for a way to generate server code without the client `Stub`. Today the generator always emits both the service behaviour and a `GRPC.Stub` client module; a server-only project ends up with a client stub it never uses, which is dead surface area and can clash with a separately generated or hand-written client. There was no switch to turn it off.

This adds a `gen_stubs` plugin option, defaulting to `true` so existing behavior is unchanged. Passing `--elixir_out=gen_stubs=false:...` (parsed in `Grpc.Protoc.CLI`) threads the flag into the service generator, and the `service.ex.eex` template conditionally omits the stub module. Default output is byte-identical to before.

## Testing

`mix test test/grpc/protoc/generator/service_test.exs` — 4 tests pass, covering default generation (stub present) and `gen_stubs: false` (stub omitted, service retained). `mix format --check-formatted` clean on the changed source files.

Fixes #549
