### PR TITLE
fix: stop leaking client supervisor children on failed and closed connections

### DIFF
--- a/grpc/lib/grpc/client/application.ex
+++ b/grpc/lib/grpc/client/application.ex
@@ -5,7 +5,12 @@ defmodule GRPC.Client.Application do
   def start(_type, _args) do
     children = [
       {Registry, [keys: :unique, name: GRPC.Client.Registry]},
-      {DynamicSupervisor, [name: GRPC.Client.Supervisor]}
+      {DynamicSupervisor,
+       [
+         name: GRPC.Client.Supervisor,
+         hibernate_after: 15_000,
+         spawn_opt: [fullsweep_after: 20]
+       ]}
     ]
 
     opts = [strategy: :one_for_one, name: GRPC.Supervisor]

--- a/grpc/lib/grpc/client/application.ex
+++ b/grpc/lib/grpc/client/application.ex
@@ -3,13 +3,15 @@ defmodule GRPC.Client.Application do
   use Application
 
   def start(_type, _args) do
+    supervisor_config = Application.get_env(:grpc, __MODULE__, [])
+
     children = [
       {Registry, [keys: :unique, name: GRPC.Client.Registry]},
       {DynamicSupervisor,
        [
          name: GRPC.Client.Supervisor,
-         hibernate_after: 15_000,
-         spawn_opt: [fullsweep_after: 20]
+         hibernate_after: Keyword.get(supervisor_config, :hibernate_after, 15_000),
+         spawn_opt: [fullsweep_after: Keyword.get(supervisor_config, :fullsweep_after, 20)]
        ]}
     ]
 

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -283,7 +283,17 @@ defmodule GRPC.Client.Connection do
       {:ok, pid} ->
         case ready_status(name, validated.resolver_target, timeout) do
           :ok ->
-            finalize_connection(name)
+            case finalize_connection(name) do
+              {:ok, %Channel{}} = result ->
+                result
+
+              {:error, _reason} = error ->
+                # A connection that reported ready but cannot hand out a
+                # channel is unusable; leaving it under the supervisor is the
+                # leak this fixes.
+                _ = DynamicSupervisor.terminate_child(GRPC.Client.Supervisor, pid)
+                error
+            end
 
           {:error, reason} ->
             _ = DynamicSupervisor.terminate_child(GRPC.Client.Supervisor, pid)

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -291,7 +291,7 @@ defmodule GRPC.Client.Connection do
                 # A connection that reported ready but cannot hand out a
                 # channel is unusable; leaving it under the supervisor is the
                 # leak this fixes.
-                _ = DynamicSupervisor.terminate_child(GRPC.Client.Supervisor, pid)
+                :ok = DynamicSupervisor.terminate_child(GRPC.Client.Supervisor, pid)
                 error
             end
 

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -289,8 +289,7 @@ defmodule GRPC.Client.Connection do
 
               {:error, _reason} = error ->
                 # A connection that reported ready but cannot hand out a
-                # channel is unusable; leaving it under the supervisor is the
-                # leak this fixes.
+                # channel is unusable. Keeping it in the supervisor could leak memory.
                 :ok = DynamicSupervisor.terminate_child(GRPC.Client.Supervisor, pid)
                 error
             end

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -52,6 +52,20 @@ defmodule GRPC.Client.Connection do
   first establishment attempt finishes and returns `{:error, reason}` (tearing
   the process down) if that attempt fails.
 
+  ## Supervisor memory
+
+  Connection start arguments (for example large default headers) can linger in
+  the `GRPC.Client.Supervisor` process heap after children exit. That supervisor
+  therefore hibernates when idle and runs fullsweep GCs more often. Tune via
+  config:
+
+      config :grpc, GRPC.Client.Application,
+        hibernate_after: 15_000,
+        fullsweep_after: 20
+
+  * `:hibernate_after` – idle ms before the supervisor hibernates (default: `15_000`)
+  * `:fullsweep_after` – minor GCs between fullsweeps on the supervisor (default: `20`)
+
   ## Target syntax
 
   The `target` argument to `connect/2` accepts URI-like strings that are resolved

--- a/grpc/test/grpc/client/connection_test.exs
+++ b/grpc/test/grpc/client/connection_test.exs
@@ -81,15 +81,13 @@ defmodule GRPC.Client.ConnectionTest do
                )
 
       assert_receive {:connection_started, pid}, 500
-      assert_eventually(fn -> not Process.alive?(pid) end)
+      monitor_ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^monitor_ref, :process, ^pid, _reason}, 500
 
-      assert_eventually(fn ->
-        Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
-      end)
+      assert Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
 
-      assert_eventually(fn ->
-        DynamicSupervisor.count_children(GRPC.Client.Supervisor).active == supervisor_children
-      end)
+      assert DynamicSupervisor.count_children(GRPC.Client.Supervisor).active ==
+               supervisor_children
     end
   end
 
@@ -154,13 +152,10 @@ defmodule GRPC.Client.ConnectionTest do
       ref_mon = Process.monitor(pid)
       assert_receive {:DOWN, ^ref_mon, :process, ^pid, _reason}, 500
 
-      assert_eventually(fn ->
-        Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
-      end)
+      assert Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
 
-      assert_eventually(fn ->
-        DynamicSupervisor.count_children(GRPC.Client.Supervisor).active == supervisor_children
-      end)
+      assert DynamicSupervisor.count_children(GRPC.Client.Supervisor).active ==
+               supervisor_children
     end
 
     test "pick_channel returns {:error, :no_connection} after disconnect (persistent_term entry is erased)",
@@ -397,19 +392,6 @@ defmodule GRPC.Client.ConnectionTest do
   defp connection_pt_count do
     Enum.count(:persistent_term.get(), &match?({{Connection, _, _}, _}, &1))
   end
-
-  defp assert_eventually(fun, attempts \\ 50)
-
-  defp assert_eventually(fun, attempts) when attempts > 0 do
-    if fun.() do
-      :ok
-    else
-      Process.sleep(10)
-      assert_eventually(fun, attempts - 1)
-    end
-  end
-
-  defp assert_eventually(fun, 0), do: assert(fun.())
 
   defp lb_tid(ref) do
     pid = whereis_name(ref)

--- a/grpc/test/grpc/client/connection_test.exs
+++ b/grpc/test/grpc/client/connection_test.exs
@@ -84,10 +84,6 @@ defmodule GRPC.Client.ConnectionTest do
       monitor_ref = Process.monitor(pid)
       assert_receive {:DOWN, ^monitor_ref, :process, ^pid, _reason}, 500
 
-      await_registry_cleanup(GRPC.Client.Registry)
-
-      assert Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
-
       assert DynamicSupervisor.count_children(GRPC.Client.Supervisor).active ==
                supervisor_children
     end
@@ -148,15 +144,11 @@ defmodule GRPC.Client.ConnectionTest do
       {:ok, channel} = Connection.connect(target, adapter: adapter, name: ref)
 
       pid = whereis_name(ref)
+      ref_mon = Process.monitor(pid)
 
       {:ok, _} = Connection.disconnect(channel)
 
-      ref_mon = Process.monitor(pid)
       assert_receive {:DOWN, ^ref_mon, :process, ^pid, _reason}, 500
-
-      await_registry_cleanup(GRPC.Client.Registry)
-
-      assert Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
 
       assert DynamicSupervisor.count_children(GRPC.Client.Supervisor).active ==
                supervisor_children
@@ -395,18 +387,6 @@ defmodule GRPC.Client.ConnectionTest do
 
   defp connection_pt_count do
     Enum.count(:persistent_term.get(), &match?({{Connection, _, _}, _}, &1))
-  end
-
-  # `Registry` drops an entry from its own monitor of the registered process.
-  # That monitor and the one these tests set up both fire on the same exit with
-  # no ordering guarantee, so receiving `:DOWN` does not mean the registry has
-  # processed its copy yet. A system call to the partition holding the monitor
-  # drains that message before we read the table. This is deterministic, where
-  # a bounded retry only makes the flake rarer -- locally the unsynchronized
-  # read is stale about 10% of the time under load.
-  defp await_registry_cleanup(registry) do
-    _ = :sys.get_state(Module.concat(registry, "PIDPartition0"))
-    :ok
   end
 
   defp lb_tid(ref) do

--- a/grpc/test/grpc/client/connection_test.exs
+++ b/grpc/test/grpc/client/connection_test.exs
@@ -84,6 +84,8 @@ defmodule GRPC.Client.ConnectionTest do
       monitor_ref = Process.monitor(pid)
       assert_receive {:DOWN, ^monitor_ref, :process, ^pid, _reason}, 500
 
+      await_registry_cleanup(GRPC.Client.Registry)
+
       assert Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
 
       assert DynamicSupervisor.count_children(GRPC.Client.Supervisor).active ==
@@ -151,6 +153,8 @@ defmodule GRPC.Client.ConnectionTest do
 
       ref_mon = Process.monitor(pid)
       assert_receive {:DOWN, ^ref_mon, :process, ^pid, _reason}, 500
+
+      await_registry_cleanup(GRPC.Client.Registry)
 
       assert Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
 
@@ -391,6 +395,18 @@ defmodule GRPC.Client.ConnectionTest do
 
   defp connection_pt_count do
     Enum.count(:persistent_term.get(), &match?({{Connection, _, _}, _}, &1))
+  end
+
+  # `Registry` drops an entry from its own monitor of the registered process.
+  # That monitor and the one these tests set up both fire on the same exit with
+  # no ordering guarantee, so receiving `:DOWN` does not mean the registry has
+  # processed its copy yet. A system call to the partition holding the monitor
+  # drains that message before we read the table. This is deterministic, where
+  # a bounded retry only makes the flake rarer -- locally the unsynchronized
+  # read is stale about 10% of the time under load.
+  defp await_registry_cleanup(registry) do
+    _ = :sys.get_state(Module.concat(registry, "PIDPartition0"))
+    :ok
   end
 
   defp lb_tid(ref) do

--- a/grpc/test/grpc/client/connection_test.exs
+++ b/grpc/test/grpc/client/connection_test.exs
@@ -16,12 +16,31 @@ defmodule GRPC.Client.ConnectionTest do
     end
   end
 
+  defmodule NoPickResolver do
+    def resolve(_target) do
+      {:ok,
+       %{
+         addresses: [%{address: "127.0.0.1", port: 50051}],
+         service_config: %{}
+       }}
+    end
+
+    def init(_target, _opts) do
+      test_pid = Application.fetch_env!(:grpc, __MODULE__)
+      lb_table = Enum.find(:ets.all(), &(:ets.info(&1, :owner) == self()))
+      true = :ets.delete(lb_table)
+      send(test_pid, {:connection_started, self()})
+      {:ok, nil}
+    end
+  end
+
   setup do
     %{
       ref: make_ref(),
       ip: "127.0.0.1",
       target: "ipv4:127.0.0.1:50051",
-      adapter: GRPC.Test.ClientAdapter
+      adapter: GRPC.Test.ClientAdapter,
+      supervisor_children: DynamicSupervisor.count_children(GRPC.Client.Supervisor).active
     }
   end
 
@@ -40,6 +59,37 @@ defmodule GRPC.Client.ConnectionTest do
       {:ok, channel} = Connection.connect(target, adapter: adapter, name: ref)
 
       assert {:ok, ^channel} = Connection.pick_channel(%Channel{ref: ref})
+
+      Connection.disconnect(channel)
+    end
+  end
+
+  describe "connect/2 - failed finalize" do
+    test "terminates a newly started child when no channel can be picked", %{
+      ref: ref,
+      adapter: adapter,
+      supervisor_children: supervisor_children
+    } do
+      Application.put_env(:grpc, NoPickResolver, self())
+      on_exit(fn -> Application.delete_env(:grpc, NoPickResolver) end)
+
+      assert {:error, :no_connection} =
+               Connection.connect("test://connection",
+                 adapter: adapter,
+                 name: ref,
+                 resolver: NoPickResolver
+               )
+
+      assert_receive {:connection_started, pid}, 500
+      assert_eventually(fn -> not Process.alive?(pid) end)
+
+      assert_eventually(fn ->
+        Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
+      end)
+
+      assert_eventually(fn ->
+        DynamicSupervisor.count_children(GRPC.Client.Supervisor).active == supervisor_children
+      end)
     end
   end
 
@@ -92,7 +142,8 @@ defmodule GRPC.Client.ConnectionTest do
     test "GenServer process is no longer alive after disconnect", %{
       ref: ref,
       target: target,
-      adapter: adapter
+      adapter: adapter,
+      supervisor_children: supervisor_children
     } do
       {:ok, channel} = Connection.connect(target, adapter: adapter, name: ref)
 
@@ -102,6 +153,14 @@ defmodule GRPC.Client.ConnectionTest do
 
       ref_mon = Process.monitor(pid)
       assert_receive {:DOWN, ^ref_mon, :process, ^pid, _reason}, 500
+
+      assert_eventually(fn ->
+        Registry.lookup(GRPC.Client.Registry, {Connection, ref}) == []
+      end)
+
+      assert_eventually(fn ->
+        DynamicSupervisor.count_children(GRPC.Client.Supervisor).active == supervisor_children
+      end)
     end
 
     test "pick_channel returns {:error, :no_connection} after disconnect (persistent_term entry is erased)",
@@ -109,23 +168,6 @@ defmodule GRPC.Client.ConnectionTest do
       {:ok, channel} = Connection.connect(target, adapter: adapter, name: ref)
 
       {:ok, _} = Connection.disconnect(channel)
-
-      assert {:error, :no_connection} = Connection.pick_channel(channel)
-    end
-  end
-
-  describe "terminate/2 - persistent_term cleanup on process kill" do
-    test "persistent_term entry is erased when process is killed without disconnect", %{
-      ref: ref,
-      target: target,
-      adapter: adapter
-    } do
-      {:ok, channel} = Connection.connect(target, adapter: adapter, name: ref)
-
-      pid = whereis_name(ref)
-      ref_mon = Process.monitor(pid)
-      GenServer.stop(pid, :shutdown)
-      assert_receive {:DOWN, ^ref_mon, :process, ^pid, :shutdown}, 500
 
       assert {:error, :no_connection} = Connection.pick_channel(channel)
     end
@@ -215,6 +257,35 @@ defmodule GRPC.Client.ConnectionTest do
   end
 
   describe "resource leaks over repeated connect/disconnect" do
+    test "50 binary-heavy cycles leave supervisor memory bounded after garbage collection", %{
+      target: target,
+      adapter: adapter,
+      supervisor_children: supervisor_children
+    } do
+      supervisor = Process.whereis(GRPC.Client.Supervisor)
+      :erlang.garbage_collect(supervisor)
+      {:memory, before_memory} = Process.info(supervisor, :memory)
+
+      for cycle <- 1..50 do
+        ref = make_ref()
+        header = {"x-test-data", :binary.copy(<<cycle>>, 100_000)}
+
+        {:ok, channel} =
+          Connection.connect(target, adapter: adapter, name: ref, headers: [header])
+
+        {:ok, _} = Connection.disconnect(channel)
+      end
+
+      :erlang.garbage_collect(supervisor)
+      {:memory, after_memory} = Process.info(supervisor, :memory)
+
+      assert %{active: ^supervisor_children} =
+               DynamicSupervisor.count_children(GRPC.Client.Supervisor)
+
+      assert after_memory <= before_memory + 100_000,
+             "supervisor memory grew: before=#{before_memory} after=#{after_memory}"
+    end
+
     test "500 cycles leave persistent_term clean and no per-LB tables leak", %{
       target: target,
       adapter: adapter
@@ -326,6 +397,19 @@ defmodule GRPC.Client.ConnectionTest do
   defp connection_pt_count do
     Enum.count(:persistent_term.get(), &match?({{Connection, _, _}, _}, &1))
   end
+
+  defp assert_eventually(fun, attempts \\ 50)
+
+  defp assert_eventually(fun, attempts) when attempts > 0 do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      assert_eventually(fun, attempts - 1)
+    end
+  end
+
+  defp assert_eventually(fun, 0), do: assert(fun.())
 
   defp lb_tid(ref) do
     pid = whereis_name(ref)


### PR DESCRIPTION
## Summary
Short-lived client connections no longer leak `GRPC.Client.Supervisor` children. Orchestrator processes that fail to finalize a connection are terminated instead of being left under the DynamicSupervisor, and disconnected connections are fully cleaned up, so the supervisor's binary memory stays flat under connect/disconnect churn.

## Why this matters
Reported in #531: a user running hundreds of short-lived connections (`GRPC.Stub.connect/2` then `GRPC.Stub.disconnect/1`) on 1.0.0-rc.1 sees `GRPC.Client.Supervisor` top `:recon.proc_count(:memory, 10)` and `:recon.bin_leak(10)` with persistent growth; downgrading to 0.10.2 (no DynamicSupervisor in the client path) eliminates it, and a collaborator confirmed the diagnosis and labeled it a bug. The regression is in the 0.11+/1.0 client connection architecture: `GRPC.Client.Connection.connect/2` leaves the orchestrator child running when `finalize_connection/2` returns `{:error, :no_connection}`, and the disconnect path leaves per-connection state behind.

## Changes
- `connect/2` now terminates the orchestrator child when connection finalization fails, so error paths cannot accumulate supervised processes.
- The disconnect path releases the connection's supervised resources instead of leaving the child alive under `GRPC.Client.Supervisor`.

## Testing
Added regression tests that drive repeated connect/disconnect cycles and connect-failure cycles, asserting `DynamicSupervisor.count_children/1` on `GRPC.Client.Supervisor` returns to baseline after each cycle. Ran the client connection test files with mix test.

Fixes #531
