### PR TITLE
Mint telemetry + overall speed-up of test suite

### DIFF
--- a/grpc/lib/grpc/client/adapters/gun/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/gun/connection_process.ex
@@ -76,9 +76,11 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
 
   @impl GenServer
   def init({%{host: host, port: port}, open_opts}) do
+    {await_timeout, open_opts} = Map.pop(open_opts, :await_timeout, 5_000)
+
     case open(host, port, open_opts) do
       {:ok, gun_pid} ->
-        case :gun.await_up(gun_pid) do
+        case :gun.await_up(gun_pid, await_timeout) do
           {:ok, :http2} ->
             {:ok, %{gun_pid: gun_pid, response_processes: %{}}}
 

--- a/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -16,6 +16,10 @@ if Code.ensure_loaded?(Mint.HTTP) do
     require State
 
     @connection_closed_error "the connection is closed"
+    @stream_response_dead_event [:grpc, :client, :mint, :stream_response, :dead]
+    @reconnect_stop_event [:grpc, :client, :mint, :reconnect, :stop]
+    @reconnect_error_event [:grpc, :client, :mint, :reconnect, :error]
+    @reconnect_exhausted_event [:grpc, :client, :mint, :reconnect, :exhausted]
 
     @doc """
     Starts and link connection process
@@ -291,6 +295,12 @@ if Code.ensure_loaded?(Mint.HTTP) do
         "stream response process #{inspect(pid)} is not alive (#{inspect(reason)}), cancelling request #{inspect(request_ref)}"
       )
 
+      :telemetry.execute(@stream_response_dead_event, %{}, %{
+        request_ref: request_ref,
+        stream_response_pid: pid,
+        reason: reason
+      })
+
       {_ref, state} = State.pop_ref(state, request_ref)
       state = drop_queued_request_chunks(state, request_ref)
 
@@ -450,6 +460,12 @@ if Code.ensure_loaded?(Mint.HTTP) do
         "Connection retry exhausted (#{attempt}/#{max}) for #{state.scheme}://#{state.host}:#{state.port}"
       )
 
+      :telemetry.execute(
+        @reconnect_exhausted_event,
+        %{},
+        reconnect_metadata(state, attempt)
+      )
+
       send(state.parent, {:elixir_grpc, :connection_down, self()})
       {:noreply, state}
     end
@@ -461,9 +477,17 @@ if Code.ensure_loaded?(Mint.HTTP) do
         "Attempting reconnection #{next_attempt}/#{state.retry} to #{state.scheme}://#{state.host}:#{state.port}"
       )
 
+      start = System.monotonic_time()
+
       case Mint.HTTP.connect(state.scheme, state.host, state.port, state.connect_opts) do
         {:ok, conn} ->
           Logger.info("Reconnected successfully to #{state.scheme}://#{state.host}:#{state.port}")
+
+          :telemetry.execute(
+            @reconnect_stop_event,
+            %{duration: System.monotonic_time() - start},
+            reconnect_metadata(state, next_attempt)
+          )
 
           new_state = %{state | conn: conn, retry_attempt: 0}
           {:noreply, new_state}
@@ -473,10 +497,26 @@ if Code.ensure_loaded?(Mint.HTTP) do
             "Reconnection attempt #{next_attempt}/#{state.retry} failed: #{inspect(reason)}"
           )
 
+          :telemetry.execute(
+            @reconnect_error_event,
+            %{duration: System.monotonic_time() - start},
+            Map.put(reconnect_metadata(state, next_attempt), :reason, reason)
+          )
+
           timeout = retry_timeout(next_attempt)
           Process.send_after(self(), :reconnect, timeout)
           {:noreply, %{state | retry_attempt: next_attempt}}
       end
+    end
+
+    defp reconnect_metadata(state, attempt) do
+      %{
+        scheme: state.scheme,
+        host: state.host,
+        port: state.port,
+        attempt: attempt,
+        max: state.retry
+      }
     end
 
     @doc false

--- a/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -234,6 +234,14 @@ if Code.ensure_loaded?(Mint.HTTP) do
       :normal
     end
 
+    # Frames may still arrive for a stream whose state was already dropped
+    # (e.g. cancelled after its response process died mid-batch). Ignore them
+    # instead of crashing the whole connection.
+    defp process_response(response, state)
+         when not State.has_request_ref(state, elem(response, 1)) do
+      state
+    end
+
     defp process_response({:status, request_ref, status}, state) do
       State.update_response_status(state, request_ref, status)
     end
@@ -241,40 +249,68 @@ if Code.ensure_loaded?(Mint.HTTP) do
     defp process_response({:headers, request_ref, headers}, state) do
       if State.empty_headers?(state, request_ref) do
         new_state = State.update_response_headers(state, request_ref, headers)
-
-        :ok =
-          new_state
-          |> State.stream_response_pid(request_ref)
-          |> StreamResponseProcess.consume(:headers, headers)
-
-        new_state
+        consume_or_cancel_stream(new_state, request_ref, :headers, headers)
       else
-        :ok =
-          state
-          |> State.stream_response_pid(request_ref)
-          |> StreamResponseProcess.consume(:trailers, headers)
-
-        state
+        consume_or_cancel_stream(state, request_ref, :trailers, headers)
       end
     end
 
     defp process_response({:data, request_ref, new_data}, state) do
-      :ok =
-        state
-        |> State.stream_response_pid(request_ref)
-        |> StreamResponseProcess.consume(:data, new_data)
-
-      state
+      consume_or_cancel_stream(state, request_ref, :data, new_data)
     end
 
-    defp process_response({:done, request_ref}, state) do
-      :ok =
-        state
-        |> State.stream_response_pid(request_ref)
-        |> StreamResponseProcess.done()
+    defp process_response({:error, request_ref, reason}, state) do
+      state
+      |> State.stream_response_pid(request_ref)
+      |> end_stream_response(reason)
 
       {_ref, new_state} = State.pop_ref(state, request_ref)
       new_state
+    end
+
+    defp process_response({:done, request_ref}, state) do
+      state
+      |> State.stream_response_pid(request_ref)
+      |> StreamResponseProcess.done()
+
+      {_ref, new_state} = State.pop_ref(state, request_ref)
+      new_state
+    end
+
+    defp consume_or_cancel_stream(state, request_ref, type, data) do
+      pid = State.stream_response_pid(state, request_ref)
+
+      case StreamResponseProcess.consume(pid, type, data) do
+        :ok -> state
+        {:error, reason} -> cancel_dead_stream(state, request_ref, pid, reason)
+      end
+    end
+
+    defp cancel_dead_stream(state, request_ref, pid, reason) do
+      Logger.warning(
+        "stream response process #{inspect(pid)} is not alive (#{inspect(reason)}), cancelling request #{inspect(request_ref)}"
+      )
+
+      {_ref, state} = State.pop_ref(state, request_ref)
+      state = drop_queued_request_chunks(state, request_ref)
+
+      case Mint.HTTP2.cancel_request(state.conn, request_ref) do
+        {:ok, conn} -> State.update_conn(state, conn)
+        {:error, conn, _error} -> State.update_conn(state, conn)
+      end
+    end
+
+    defp drop_queued_request_chunks(state, request_ref) do
+      {dropped, kept} =
+        state.request_stream_queue
+        |> :queue.to_list()
+        |> Enum.split_with(&match?({^request_ref, _body, _from}, &1))
+
+      for {_ref, _body, from} <- dropped, not is_nil(from) do
+        GenServer.reply(from, {:error, "the request was cancelled"})
+      end
+
+      State.update_request_stream_queue(state, :queue.from_list(kept))
     end
 
     defp chunk_body_and_enqueue_rest({request_ref, body, from}, state) do
@@ -297,10 +333,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
             # isn't the same one that's expecting the reply.
             GenServer.reply(from, {:error, error})
           else
-            :ok =
-              state
-              |> State.stream_response_pid(request_ref)
-              |> StreamResponseProcess.consume(:error, error)
+            state
+            |> State.stream_response_pid(request_ref)
+            |> StreamResponseProcess.consume(:error, error)
           end
 
           {:noreply, State.update_conn(state, conn)}
@@ -322,10 +357,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
           if not send_eof? do
             GenServer.reply(from, {:error, error})
           else
-            :ok =
-              state
-              |> State.stream_response_pid(request_ref)
-              |> StreamResponseProcess.consume(:error, error)
+            state
+            |> State.stream_response_pid(request_ref)
+            |> StreamResponseProcess.consume(:error, error)
           end
 
           check_request_stream_queue(State.update_conn(state, conn))
@@ -374,12 +408,12 @@ if Code.ensure_loaded?(Mint.HTTP) do
             {ref, _body, nil} ->
               acc_state
               |> State.stream_response_pid(ref)
-              |> send_connection_close_and_end_stream_response()
+              |> end_stream_response(@connection_closed_error)
 
             {ref, _body, from} ->
               acc_state
               |> State.stream_response_pid(ref)
-              |> send_connection_close_and_end_stream_response()
+              |> end_stream_response(@connection_closed_error)
 
               GenServer.reply(from, {:error, @connection_closed_error})
           end
@@ -392,7 +426,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
       |> Enum.each(fn {ref, _} ->
         new_state
         |> State.stream_response_pid(ref)
-        |> send_connection_close_and_end_stream_response()
+        |> end_stream_response(@connection_closed_error)
       end)
 
       clean_state = State.update_request_stream_queue(%{new_state | requests: %{}}, :queue.new())
@@ -405,9 +439,9 @@ if Code.ensure_loaded?(Mint.HTTP) do
       end
     end
 
-    defp send_connection_close_and_end_stream_response(pid) do
-      :ok = StreamResponseProcess.consume(pid, :error, @connection_closed_error)
-      :ok = StreamResponseProcess.done(pid)
+    defp end_stream_response(pid, error) do
+      StreamResponseProcess.consume(pid, :error, error)
+      StreamResponseProcess.done(pid)
     end
 
     defp attempt_reconnect(%{retry: max, retry_attempt: attempt} = state)

--- a/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/mint/connection_process/connection_process.ex
@@ -503,7 +503,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
             Map.put(reconnect_metadata(state, next_attempt), :reason, reason)
           )
 
-          timeout = retry_timeout(next_attempt)
+          timeout = state.retry_timeout_ms || retry_timeout(next_attempt)
           Process.send_after(self(), :reconnect, timeout)
           {:noreply, %{state | retry_attempt: next_attempt}}
       end

--- a/grpc/lib/grpc/client/adapters/mint/connection_process/state.ex
+++ b/grpc/lib/grpc/client/adapters/mint/connection_process/state.ex
@@ -9,6 +9,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
       :host,
       :port,
       :connect_opts,
+      :retry_timeout_ms,
       requests: %{},
       request_stream_queue: :queue.new(),
       retry: 0,
@@ -23,6 +24,7 @@ if Code.ensure_loaded?(Mint.HTTP) do
             host: Mint.Types.address() | nil,
             port: :inet.port_number() | nil,
             connect_opts: keyword(),
+            retry_timeout_ms: non_neg_integer() | nil,
             retry: non_neg_integer(),
             retry_attempt: non_neg_integer()
           }

--- a/grpc/lib/grpc/client/adapters/mint/stream_response_process.ex
+++ b/grpc/lib/grpc/client/adapters/mint/stream_response_process.ex
@@ -16,7 +16,7 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
   # available inside the process.
   #
   # TODO: Refactor the GenServer.call/3 occurrences on this module to produce
-  # telemetry events and log entries in case of failures
+  # telemetry events in case of failures
 
   @accepted_types [:data, :trailers, :headers, :error]
   @header_types [:headers, :trailers]
@@ -55,18 +55,26 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcess do
   Cast a message to process to inform that the stream has finished
     once all messages are produced. This process will automatically
     be killed.
+
+  Returns `:ok`, or `{:error, reason}` when the stream response process
+  is no longer alive (e.g. the caller gave up on the request).
   """
   def done(pid) do
-    :ok = GenServer.call(pid, {:consume_response, :done})
-    :ok
+    GenServer.call(pid, {:consume_response, :done})
+  catch
+    :exit, {reason, {GenServer, :call, _args}} -> {:error, reason}
   end
 
   @doc """
-  Consume an incoming data or trailers/headers
+  Consume an incoming data or trailers/headers.
+
+  Returns `:ok`, or `{:error, reason}` when the stream response process
+  is no longer alive (e.g. the caller gave up on the request).
   """
   def consume(pid, type, data) when type in @accepted_types do
-    :ok = GenServer.call(pid, {:consume_response, {type, data}})
-    :ok
+    GenServer.call(pid, {:consume_response, {type, data}})
+  catch
+    :exit, {reason, {GenServer, :call, _args}} -> {:error, reason}
   end
 
   # Callbacks

--- a/grpc/test/grpc/adapters/gun_test.exs
+++ b/grpc/test/grpc/adapters/gun_test.exs
@@ -3,14 +3,19 @@ defmodule GRPC.Client.Adapters.GunTest do
 
   alias GRPC.Client.Adapters.Gun
 
+  defmodule Endpoint do
+    use GRPC.Endpoint
+    run(FeatureServer)
+  end
+
   setup do
     server_credential = build(:credential)
 
     {:ok, _, port} =
-      GRPC.Server.start(FeatureServer, 0, adapter_opts: [cred: server_credential])
+      GRPC.Server.start_endpoint(Endpoint, 0, adapter_opts: [cred: server_credential])
 
     on_exit(fn ->
-      :ok = GRPC.Server.stop(FeatureServer)
+      :ok = GRPC.Server.stop_endpoint(Endpoint)
     end)
 
     %{
@@ -84,6 +89,7 @@ defmodule GRPC.Client.Adapters.GunTest do
       # Ensure that changing one of the options breaks things
       assert {:error, :timeout} ==
                Gun.connect(channel,
+                 await_timeout: 100,
                  transport_opts: [
                    certfile: credential.ssl[:certfile] <> "invalidsuffix",
                    verify: :verify_peer,

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -579,8 +579,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
       :ok = ConnectionProcess.stream_request_body(pid, request_ref, :eof)
 
-      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{},
-                      metadata}
+      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{}, metadata}
 
       assert metadata.request_ref == request_ref
       assert metadata.stream_response_pid == dead_pid

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -708,11 +708,24 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
   end
 
   defp valid_stream_request(%{request: {method, path, headers}, process_pid: pid}) do
+    # Must not use self() here: a fast server response makes ConnectionProcess
+    # GenServer.call the stream response pid while this setup is blocked in
+    # :sys.get_state/1, which deadlocks the test process.
+    stream = build(:client_stream)
+    {:ok, stream_response_pid} = StreamResponseProcess.start_link(stream, true)
+
     {:ok, %{request_ref: request_ref}} =
-      ConnectionProcess.request(pid, method, path, headers, :stream, stream_response_pid: self())
+      ConnectionProcess.request(pid, method, path, headers, :stream,
+        stream_response_pid: stream_response_pid
+      )
 
     state = :sys.get_state(pid)
-    %{request_ref: request_ref, state: state}
+
+    %{
+      request_ref: request_ref,
+      state: state,
+      stream_response_pid: stream_response_pid
+    }
   end
 
   defp valid_stream_response(%{request_ref: request_ref, state: state} = ctx) do

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -579,7 +579,8 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
       :ok = ConnectionProcess.stream_request_body(pid, request_ref, :eof)
 
-      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{}, metadata}
+      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{}, metadata},
+                     500
 
       assert metadata.request_ref == request_ref
       assert metadata.stream_response_pid == dead_pid

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -1,15 +1,32 @@
 defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
-  use GRPC.Client.DataCase
+  use GRPC.Client.DataCase, async: true
   alias GRPC.Client.Adapters.Mint.ConnectionProcess
   alias GRPC.Client.Adapters.Mint.StreamResponseProcess
 
   import ExUnit.CaptureLog
 
-  setup do
-    {:ok, _, port} = GRPC.Server.start(FeatureServer, 0)
+  # Unique Ranch listener names so this module can run async without racing
+  # other suites that still start the shared FeatureServer module directly.
+  defmodule Endpoint do
+    use GRPC.Endpoint
+    run(FeatureServer)
+  end
+
+  defmodule ReconnectExhaustedEndpoint do
+    use GRPC.Endpoint
+    run(FeatureServer)
+  end
+
+  defmodule ReconnectUnavailableEndpoint do
+    use GRPC.Endpoint
+    run(FeatureServer)
+  end
+
+  setup_all do
+    {:ok, _, port} = GRPC.Server.start_endpoint(Endpoint, 0)
 
     on_exit(fn ->
-      :ok = GRPC.Server.stop(FeatureServer)
+      :ok = GRPC.Server.stop_endpoint(Endpoint)
     end)
 
     %{port: port}
@@ -407,6 +424,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
   describe "handle_info - connection_closed - with retry" do
     setup :valid_connection_with_retry
+    setup :attach_reconnect_telemetry
 
     test "attempts reconnect when retry > 0 and connection drops", %{
       state: state
@@ -419,24 +437,31 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
       assert new_state.retry_attempt == 0
       refute_receive {:elixir_grpc, :connection_down, _pid}, 200
     end
+  end
+
+  describe "handle_info - connection_closed - with retry - exhausted" do
+    @describetag private_endpoint: ReconnectExhaustedEndpoint
+    setup :start_private_endpoint
+    setup :valid_connection_with_retry
+    setup :attach_reconnect_telemetry
 
     test "notifies parent when all retry attempts are exhausted", %{
       state: state,
       port: port
     } do
-      :ok = GRPC.Server.stop(FeatureServer)
+      :ok = GRPC.Server.stop_endpoint(ReconnectExhaustedEndpoint)
 
-      logs =
-        capture_log(fn ->
-          exhausted_state = %{state | retry: 1, retry_attempt: 1}
-          result = ConnectionProcess.handle_info(:reconnect, exhausted_state)
-          assert {:noreply, _} = result
-          assert_receive {:elixir_grpc, :connection_down, _pid}, 500
-        end)
+      exhausted_state = %{state | retry: 1, retry_attempt: 1}
+      result = ConnectionProcess.handle_info(:reconnect, exhausted_state)
+      assert {:noreply, _} = result
+      assert_receive {:elixir_grpc, :connection_down, _pid}, 500
 
-      assert logs =~ "Connection retry exhausted"
-
-      {:ok, _, _} = GRPC.Server.start(FeatureServer, port)
+      assert_receive {:telemetry, [:grpc, :client, :mint, :reconnect, :exhausted], %{}, metadata}
+      assert metadata.attempt == 1
+      assert metadata.max == 1
+      assert metadata.host == "localhost"
+      assert metadata.port == port
+      assert metadata.scheme == :http
     end
   end
 
@@ -519,6 +544,23 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
   describe "handle_info - response frames for a dead stream response process" do
     setup :valid_connection
 
+    setup do
+      test_pid = self()
+      handler_id = "test-stream-response-dead-#{inspect(test_pid)}"
+
+      :telemetry.attach(
+        handler_id,
+        [:grpc, :client, :mint, :stream_response, :dead],
+        fn name, measurements, metadata, [] ->
+          send(test_pid, {:telemetry, name, measurements, metadata})
+        end,
+        []
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
     test "cancels the affected request and keeps the connection alive", %{
       process_pid: pid,
       request: {method, path, headers}
@@ -527,20 +569,20 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
       monitor = Process.monitor(dead_pid)
       assert_receive {:DOWN, ^monitor, :process, ^dead_pid, _reason}
 
-      logs =
-        capture_log(fn ->
-          {:ok, %{request_ref: request_ref}} =
-            ConnectionProcess.request(pid, method, path, headers, :stream,
-              stream_response_pid: dead_pid
-            )
+      {:ok, %{request_ref: request_ref}} =
+        ConnectionProcess.request(pid, method, path, headers, :stream,
+          stream_response_pid: dead_pid
+        )
 
-          :ok = ConnectionProcess.stream_request_body(pid, request_ref, :eof)
+      :ok = ConnectionProcess.stream_request_body(pid, request_ref, :eof)
 
-          wait_until(fn -> :sys.get_state(pid).requests == %{} end)
-        end)
+      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{},
+                      metadata}
 
+      assert metadata.request_ref == request_ref
+      assert metadata.stream_response_pid == dead_pid
+      assert metadata.reason != nil
       assert Process.alive?(pid)
-      assert logs =~ "is not alive"
     end
   end
 
@@ -566,40 +608,70 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
   describe "handle_info :reconnect" do
     setup :valid_connection_with_retry
+    setup :attach_reconnect_telemetry
 
     test "successfully reconnects when server is available", %{
-      state: state
+      state: state,
+      port: port
     } do
       failed_state = %{state | retry_attempt: 1}
 
-      logs =
-        capture_log(fn ->
-          assert {:noreply, new_state} = ConnectionProcess.handle_info(:reconnect, failed_state)
-          assert Mint.HTTP.open?(new_state.conn)
-          assert new_state.retry_attempt == 0
-        end)
+      assert {:noreply, new_state} = ConnectionProcess.handle_info(:reconnect, failed_state)
+      assert Mint.HTTP.open?(new_state.conn)
+      assert new_state.retry_attempt == 0
 
-      assert logs =~ "Reconnected successfully"
+      assert_receive {:telemetry, [:grpc, :client, :mint, :reconnect, :stop], measurements,
+                      metadata}
+
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+      assert metadata.attempt == 2
+      assert metadata.max == 3
+      assert metadata.host == "localhost"
+      assert metadata.port == port
+      assert metadata.scheme == :http
     end
+  end
+
+  describe "handle_info :reconnect - unavailable" do
+    @describetag private_endpoint: ReconnectUnavailableEndpoint
+    setup :start_private_endpoint
+    setup :valid_connection_with_retry
+    setup :attach_reconnect_telemetry
 
     test "schedules another reconnect when server is unavailable", %{
       state: state,
       port: port
     } do
-      :ok = GRPC.Server.stop(FeatureServer)
+      :ok = GRPC.Server.stop_endpoint(ReconnectUnavailableEndpoint)
 
-      logs =
-        capture_log(fn ->
-          failed_state = %{state | retry_attempt: 0}
-          assert {:noreply, new_state} = ConnectionProcess.handle_info(:reconnect, failed_state)
-          assert new_state.retry_attempt == 1
-          assert_receive :reconnect, 5_000
-        end)
+      failed_state = %{state | retry_attempt: 0}
+      assert {:noreply, new_state} = ConnectionProcess.handle_info(:reconnect, failed_state)
+      assert new_state.retry_attempt == 1
+      assert_receive :reconnect, 5_000
 
-      assert logs =~ "Reconnection attempt 1/"
+      assert_receive {:telemetry, [:grpc, :client, :mint, :reconnect, :error], measurements,
+                      metadata}
 
-      {:ok, _, _} = GRPC.Server.start(FeatureServer, port)
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+      assert metadata.attempt == 1
+      assert metadata.max == 3
+      assert metadata.host == "localhost"
+      assert metadata.port == port
+      assert metadata.scheme == :http
+      assert metadata.reason != nil
     end
+  end
+
+  defp start_private_endpoint(%{private_endpoint: endpoint}) do
+    {:ok, _, port} = GRPC.Server.start_endpoint(endpoint, 0)
+
+    on_exit(fn ->
+      _ = GRPC.Server.stop_endpoint(endpoint)
+    end)
+
+    %{port: port}
   end
 
   defp valid_connection(%{port: port}, opts \\ []) do
@@ -651,18 +723,24 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
   defp valid_connection_with_retry(ctx), do: valid_connection(ctx, retry: 3)
 
-  defp wait_until(fun, timeout \\ 2_000)
+  defp attach_reconnect_telemetry(_ctx) do
+    test_pid = self()
+    handler_id = "test-reconnect-telemetry-#{inspect(test_pid)}"
 
-  defp wait_until(fun, timeout) when timeout <= 0 do
-    assert fun.()
-  end
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:grpc, :client, :mint, :reconnect, :stop],
+        [:grpc, :client, :mint, :reconnect, :error],
+        [:grpc, :client, :mint, :reconnect, :exhausted]
+      ],
+      fn name, measurements, metadata, [] ->
+        send(test_pid, {:telemetry, name, measurements, metadata})
+      end,
+      []
+    )
 
-  defp wait_until(fun, timeout) do
-    if fun.() do
-      :ok
-    else
-      Process.sleep(20)
-      wait_until(fun, timeout - 20)
-    end
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    :ok
   end
 end

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -579,7 +579,8 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
       :ok = ConnectionProcess.stream_request_body(pid, request_ref, :eof)
 
-      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{}, metadata},
+      assert_receive {:telemetry, [:grpc, :client, :mint, :stream_response, :dead], %{},
+                      metadata},
                      500
 
       assert metadata.request_ref == request_ref

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -447,8 +447,11 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
     test "notifies parent when all retry attempts are exhausted", %{
       state: state,
-      port: port
+      port: port,
+      process_pid: pid
     } do
+      # Close the live client first so Cowboy shutdown does not wait on drain.
+      :ok = ConnectionProcess.disconnect(pid)
       :ok = GRPC.Server.stop_endpoint(ReconnectExhaustedEndpoint)
 
       exhausted_state = %{state | retry: 1, retry_attempt: 1}
@@ -459,7 +462,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
       assert_receive {:telemetry, [:grpc, :client, :mint, :reconnect, :exhausted], %{}, metadata}
       assert metadata.attempt == 1
       assert metadata.max == 1
-      assert metadata.host == "localhost"
+      assert metadata.host == "127.0.0.1"
       assert metadata.port == port
       assert metadata.scheme == :http
     end
@@ -627,7 +630,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
       assert measurements.duration >= 0
       assert metadata.attempt == 2
       assert metadata.max == 3
-      assert metadata.host == "localhost"
+      assert metadata.host == "127.0.0.1"
       assert metadata.port == port
       assert metadata.scheme == :http
     end
@@ -641,11 +644,14 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
 
     test "schedules another reconnect when server is unavailable", %{
       state: state,
-      port: port
+      port: port,
+      process_pid: pid
     } do
+      # Close the live client first so Cowboy shutdown does not wait on drain.
+      :ok = ConnectionProcess.disconnect(pid)
       :ok = GRPC.Server.stop_endpoint(ReconnectUnavailableEndpoint)
 
-      failed_state = %{state | retry_attempt: 0}
+      failed_state = %{state | retry_attempt: 0, retry_timeout_ms: 10}
       assert {:noreply, new_state} = ConnectionProcess.handle_info(:reconnect, failed_state)
       assert new_state.retry_attempt == 1
       assert_receive :reconnect, 5_000
@@ -657,7 +663,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
       assert measurements.duration >= 0
       assert metadata.attempt == 1
       assert metadata.max == 3
-      assert metadata.host == "localhost"
+      assert metadata.host == "127.0.0.1"
       assert metadata.port == port
       assert metadata.scheme == :http
       assert metadata.reason != nil
@@ -678,7 +684,7 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
     {:ok, pid} =
       ConnectionProcess.start_link(
         :http,
-        "localhost",
+        "127.0.0.1",
         port,
         Keyword.merge([protocols: [:http2]], opts)
       )

--- a/grpc/test/grpc/adapters/mint/connection_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/connection_process_test.exs
@@ -212,6 +212,22 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
       assert true == response_state.done
     end
 
+    test "replies :ok and pops the ref when the stream response process is dead",
+         %{
+           request_ref: request_ref,
+           stream_response_pid: response_pid,
+           state: state
+         } do
+      Process.unlink(response_pid)
+      monitor = Process.monitor(response_pid)
+      Process.exit(response_pid, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^response_pid, :killed}
+
+      response = ConnectionProcess.handle_call({:cancel_request, request_ref}, nil, state)
+      assert {:reply, :ok, new_state} = response
+      assert %{} == new_state.requests
+    end
+
     test "is a no-op on state.requests when the ref was already popped",
          %{request_ref: request_ref, state: state} do
       {_ref, state_without_ref} = pop_in(state.requests[request_ref])
@@ -476,6 +492,58 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
     end
   end
 
+  describe "handle_info - connection_closed - with dead stream response process" do
+    setup :valid_connection
+    setup :valid_stream_request
+    setup :valid_stream_response
+
+    test "does not crash when ending the stream response process fails",
+         %{
+           state: state,
+           stream_response_pid: response_pid
+         } do
+      Process.unlink(response_pid)
+      monitor = Process.monitor(response_pid)
+      Process.exit(response_pid, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^response_pid, :killed}
+
+      socket = state.conn.socket
+      tcp_message = {:tcp_closed, socket}
+
+      assert {:noreply, new_state} = ConnectionProcess.handle_info(tcp_message, state)
+      assert new_state.conn.state == :closed
+      assert_receive {:elixir_grpc, :connection_down, _pid}, 500
+    end
+  end
+
+  describe "handle_info - response frames for a dead stream response process" do
+    setup :valid_connection
+
+    test "cancels the affected request and keeps the connection alive", %{
+      process_pid: pid,
+      request: {method, path, headers}
+    } do
+      dead_pid = spawn(fn -> :ok end)
+      monitor = Process.monitor(dead_pid)
+      assert_receive {:DOWN, ^monitor, :process, ^dead_pid, _reason}
+
+      logs =
+        capture_log(fn ->
+          {:ok, %{request_ref: request_ref}} =
+            ConnectionProcess.request(pid, method, path, headers, :stream,
+              stream_response_pid: dead_pid
+            )
+
+          :ok = ConnectionProcess.stream_request_body(pid, request_ref, :eof)
+
+          wait_until(fn -> :sys.get_state(pid).requests == %{} end)
+        end)
+
+      assert Process.alive?(pid)
+      assert logs =~ "is not alive"
+    end
+  end
+
   describe "retry_timeout/1" do
     test "returns exponentially increasing timeouts" do
       t1 = ConnectionProcess.retry_timeout(1)
@@ -582,4 +650,19 @@ defmodule GRPC.Client.Adapters.Mint.ConnectionProcessTest do
   end
 
   defp valid_connection_with_retry(ctx), do: valid_connection(ctx, retry: 3)
+
+  defp wait_until(fun, timeout \\ 2_000)
+
+  defp wait_until(fun, timeout) when timeout <= 0 do
+    assert fun.()
+  end
+
+  defp wait_until(fun, timeout) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(20)
+      wait_until(fun, timeout - 20)
+    end
+  end
 end

--- a/grpc/test/grpc/adapters/mint/stream_response_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/stream_response_process_test.exs
@@ -341,6 +341,19 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcessTest do
     end
   end
 
+  describe "consume/3 and done/1 - process no longer alive" do
+    test "return an error instead of exiting the caller" do
+      {:ok, pid} = StreamResponseProcess.start_link(build(:client_stream), true)
+      Process.unlink(pid)
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+
+      assert {:error, :noproc} == StreamResponseProcess.consume(pid, :data, <<0>>)
+      assert {:error, :noproc} == StreamResponseProcess.done(pid)
+    end
+  end
+
   describe "build_stream/1" do
     setup do
       {:ok, pid} = StreamResponseProcess.start_link(build(:client_stream), true)

--- a/grpc/test/grpc/adapters/mint/stream_response_process_test.exs
+++ b/grpc/test/grpc/adapters/mint/stream_response_process_test.exs
@@ -343,11 +343,9 @@ defmodule GRPC.Client.Adapters.Mint.StreamResponseProcessTest do
 
   describe "consume/3 and done/1 - process no longer alive" do
     test "return an error instead of exiting the caller" do
-      {:ok, pid} = StreamResponseProcess.start_link(build(:client_stream), true)
-      Process.unlink(pid)
-      ref = Process.monitor(pid)
+      pid = spawn(fn -> :ok end)
       Process.exit(pid, :kill)
-      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+      refute Process.alive?(pid)
 
       assert {:error, :noproc} == StreamResponseProcess.consume(pid, :data, <<0>>)
       assert {:error, :noproc} == StreamResponseProcess.done(pid)

--- a/grpc/test/grpc/client/dns_resolver_test.exs
+++ b/grpc/test/grpc/client/dns_resolver_test.exs
@@ -30,9 +30,9 @@ defmodule GRPC.Client.ReResolveTest do
   alias GRPC.Channel
   alias GRPC.Client.Connection
 
-  @resolve_interval 200
-  @wait @resolve_interval + 100
-  @wait_after_backoff @resolve_interval * 2 + 150
+  @resolve_interval 50
+  @wait @resolve_interval + 30
+  @wait_after_backoff @resolve_interval * 2 + 50
 
   setup do
     Mox.set_mox_global()
@@ -666,7 +666,7 @@ defmodule GRPC.Client.ReResolveTest do
           resolve_interval: 50
         )
 
-      Process.sleep(200)
+      Process.sleep(@wait)
 
       assert {:ok, _} = Connection.pick_channel(channel)
       assert is_nil(get_state(ctx.ref).resolver_state)
@@ -1160,9 +1160,9 @@ defmodule GRPC.Client.ReResolveTest do
           lb_policy: :round_robin
         )
 
-      # Simulate a resolver that takes a long time
+      # Simulate a resolver that takes long enough to overlap pick_channel
       stub(ctx.resolver, :resolve, fn _target ->
-        Process.sleep(2_000)
+        Process.sleep(200)
         {:ok, %{addresses: [%{address: "10.0.0.1", port: 50051}], service_config: nil}}
       end)
 

--- a/grpc/test/grpc/integration/client_interceptor_test.exs
+++ b/grpc/test/grpc/integration/client_interceptor_test.exs
@@ -101,7 +101,7 @@ defmodule GRPC.Integration.ClientInterceptorTest do
       ])
 
       run_endpoint(HelloEndpoint, fn port ->
-        delay = floor(:rand.uniform() * 500) + 500
+        delay = 10
 
         {:ok, channel} =
           GRPC.Stub.connect("localhost:#{port}",
@@ -125,7 +125,9 @@ defmodule GRPC.Integration.ClientInterceptorTest do
 
         assert_received {^exception_client_name, measurements, metadata}
         assert %{duration: duration} = measurements
-        assert duration > delay
+
+        assert System.convert_time_unit(duration, :native, :millisecond) >= delay
+
         assert is_map(metadata)
         assert is_list(Map.get(metadata, :stacktrace, []))
       end)

--- a/grpc/test/grpc/integration/server_test.exs
+++ b/grpc/test/grpc/integration/server_test.exs
@@ -764,7 +764,7 @@ defmodule GRPC.Integration.ServerTest do
       run_server([HelloServer], fn port ->
         {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
 
-        req = %Helloworld.HelloRequest{name: "delay", duration: 1000}
+        req = %Helloworld.HelloRequest{name: "delay", duration: 20}
 
         assert {:ok, _} = Helloworld.Greeter.Stub.say_hello(channel, req)
       end)
@@ -781,7 +781,7 @@ defmodule GRPC.Integration.ServerTest do
 
       assert_received {^stop_server_name, measurements, metadata}
       assert %{duration: duration} = measurements
-      assert duration > 1000
+      assert System.convert_time_unit(duration, :native, :millisecond) >= 20
 
       assert %{
                server: HelloServer,
@@ -803,7 +803,7 @@ defmodule GRPC.Integration.ServerTest do
 
       assert_received {^stop_client_name, measurements, metadata}
       assert %{duration: duration} = measurements
-      assert duration > 1100
+      assert System.convert_time_unit(duration, :native, :millisecond) >= 20
 
       assert %{
                stream: %GRPC.Client.Stream{
@@ -839,7 +839,7 @@ defmodule GRPC.Integration.ServerTest do
       run_server([HelloServer], fn port ->
         {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
 
-        req = %Helloworld.HelloRequest{name: "raise", duration: 1100}
+        req = %Helloworld.HelloRequest{name: "raise", duration: 20}
 
         assert {:error, %GRPC.RPCError{status: 2}} =
                  Helloworld.Greeter.Stub.say_hello(channel, req)
@@ -857,7 +857,7 @@ defmodule GRPC.Integration.ServerTest do
 
       assert_received {^exception_server_name, measurements, metadata}
       assert %{duration: duration} = measurements
-      assert duration > 1100
+      assert System.convert_time_unit(duration, :native, :millisecond) >= 20
 
       assert %{
                server: HelloServer,
@@ -893,7 +893,7 @@ defmodule GRPC.Integration.ServerTest do
 
       assert_received {^stop_client_name, measurements, metadata}
       assert %{duration: duration} = measurements
-      assert duration > 1100
+      assert System.convert_time_unit(duration, :native, :millisecond) >= 20
 
       assert %{
                stream: %GRPC.Client.Stream{


### PR DESCRIPTION
This improved testing strategy and observability of the Mint client by introducing telemetry events.
Also improves overall speed of the test suite (30s down to 8s on my machine)