### PR TITLE
refactor: remove GRPC.Channel.t() typespec (unbreaks connect/2 success typing)

### DIFF
--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 
-  * `GRPC.Channel.t()` now types `host`, `port`, `scheme`, `cred`, and `compressor` as nilable and `interceptors` as `list()`, matching the struct's defaults. Previously they were declared non-nil (and `interceptors` as `[]`), so a virtual channel (built with `host: nil`/`port: nil`) violated the type. Combined with `pick_channel/2`'s `@spec`, this made Dialyzer infer `connect/2` could only return `{:error, _}`, spuriously flagging `{:ok, channel}` matches in downstream code as unreachable.
+  * Removed the `GRPC.Channel.t()` typespec. It declared `host`/`port` non-nil and `interceptors` as `[]`, but a virtual channel (built with `host: nil`/`port: nil` and a non-empty `interceptors` list) violated the type. Combined with `pick_channel/2`'s `@spec`, this made Dialyzer infer `connect/2` could only return `{:error, _}`, spuriously flagging `{:ok, channel}` matches in downstream code as unreachable. References to the type are now `struct()`.
 
 ## v1.0.0 (2026-06-15)
 

--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -13,6 +13,10 @@
   * When all resolved addresses fail to dial, `connect/2` returns the first underlying dial error (e.g. `{:error, :connection_refused}`) instead of `{:error, :no_addresses}`.
   * Calling `connect/2` with a `:name` already registered to a different target now returns `{:error, {:already_started_with_different_target, target}}` instead of silently returning the existing connection's channel.
 
+### Bug Fixes
+
+  * `GRPC.Channel.t()` now types `host`, `port`, `scheme`, `cred`, and `compressor` as nilable and `interceptors` as `list()`, matching the struct's defaults. Previously they were declared non-nil (and `interceptors` as `[]`), so a virtual channel (built with `host: nil`/`port: nil`) violated the type. Combined with `pick_channel/2`'s `@spec`, this made Dialyzer infer `connect/2` could only return `{:error, _}`, spuriously flagging `{:ok, channel}` matches in downstream code as unreachable.
+
 ## v1.0.0 (2026-06-15)
 
 ### Enhancements

--- a/grpc/lib/grpc/channel.ex
+++ b/grpc/lib/grpc/channel.ex
@@ -16,20 +16,6 @@ defmodule GRPC.Channel do
     * `:adapter_payload` - payload the adapter uses
   """
 
-  @type t :: %__MODULE__{
-          host: String.t() | nil,
-          port: non_neg_integer() | nil,
-          scheme: String.t() | nil,
-          cred: GRPC.Credential.t() | nil,
-          ref: reference() | nil,
-          adapter: atom(),
-          adapter_payload: any(),
-          codec: module(),
-          interceptors: list(),
-          compressor: module() | nil,
-          accepted_compressors: [module()],
-          headers: list()
-        }
   defstruct host: nil,
             port: nil,
             scheme: nil,

--- a/grpc/lib/grpc/channel.ex
+++ b/grpc/lib/grpc/channel.ex
@@ -17,16 +17,16 @@ defmodule GRPC.Channel do
   """
 
   @type t :: %__MODULE__{
-          host: String.t(),
-          port: non_neg_integer(),
-          scheme: String.t(),
-          cred: GRPC.Credential.t(),
+          host: String.t() | nil,
+          port: non_neg_integer() | nil,
+          scheme: String.t() | nil,
+          cred: GRPC.Credential.t() | nil,
           ref: reference() | nil,
           adapter: atom(),
           adapter_payload: any(),
           codec: module(),
-          interceptors: [],
-          compressor: module(),
+          interceptors: list(),
+          compressor: module() | nil,
           accepted_compressors: [module()],
           headers: list()
         }

--- a/grpc/lib/grpc/client/adapter.ex
+++ b/grpc/lib/grpc/client/adapter.ex
@@ -3,15 +3,14 @@ defmodule GRPC.Client.Adapter do
   HTTP client adapter for GRPC.
   """
   alias GRPC.Client.Stream
-  alias GRPC.Channel
 
   @typedoc "Determines if the headers have finished being read."
   @type fin :: :fin | :nofin
 
-  @callback connect(channel :: Channel.t(), opts :: keyword()) ::
-              {:ok, Channel.t()} | {:error, any()}
+  @callback connect(channel :: struct(), opts :: keyword()) ::
+              {:ok, struct()} | {:error, any()}
 
-  @callback disconnect(channel :: Channel.t()) :: {:ok, Channel.t()} | {:error, any()}
+  @callback disconnect(channel :: struct()) :: {:ok, struct()} | {:error, any()}
 
   @callback send_request(stream :: Stream.t(), contents :: iodata(), opts :: keyword()) ::
               Stream.t()

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -153,8 +153,8 @@ defmodule GRPC.Client.Connection do
   @await_ready_stop_event [:grpc, :client, :connection, :await_ready, :stop]
 
   @type t :: %__MODULE__{
-          virtual_channel: Channel.t(),
-          real_channels: %{String.t() => {:connected, Channel.t()} | {:failed, any()}},
+          virtual_channel: struct(),
+          real_channels: %{String.t() => {:connected, struct()} | {:failed, any()}},
           lb_mod: module() | nil,
           lb_state: term() | nil,
           resolver: module() | nil,

--- a/grpc/lib/grpc/client/load_balacing.ex
+++ b/grpc/lib/grpc/client/load_balacing.ex
@@ -1,13 +1,11 @@
 defmodule GRPC.Client.LoadBalancing do
   @moduledoc "Load balancing behaviour for gRPC clients."
 
-  alias GRPC.Channel
-
   @callback init(opts :: keyword()) :: {:ok, state :: any()} | {:error, reason :: any()}
 
   @callback pick(state :: any()) ::
-              {:ok, Channel.t(), new_state :: any()} | {:error, reason :: any()}
+              {:ok, struct(), new_state :: any()} | {:error, reason :: any()}
 
-  @callback update(state :: any(), new_channels :: [Channel.t()]) ::
+  @callback update(state :: any(), new_channels :: [struct()]) ::
               {:ok, new_state :: any()} | {:error, reason :: any()}
 end

--- a/grpc/lib/grpc/client/stream.ex
+++ b/grpc/lib/grpc/client/stream.ex
@@ -16,7 +16,7 @@ defmodule GRPC.Client.Stream do
 
   @typep stream_payload :: any()
   @type t :: %__MODULE__{
-          channel: GRPC.Channel.t(),
+          channel: struct(),
           service_name: String.t(),
           method_name: String.t(),
           grpc_type: atom(),


### PR DESCRIPTION
## Summary

`GRPC.Channel`'s `@type t` was narrower than the struct's actual value space,
which made Dialyzer infer that `GRPC.Stub.connect/2` could only return
`{:error, _}`. Any downstream code matching `{:ok, channel}` on the result then
got a spurious `pattern_match` warning ("The pattern `{:ok, _}` can never match
the type `{:error, _}`"), even though at runtime `connect/2` returns
`{:ok, channel}` normally.

Per review, rather than relaxing the type to match the `defstruct` defaults,
this PR **removes the `GRPC.Channel.t()` typespec altogether**. Typespec-only,
no behavior change.

## Root cause

```elixir
# lib/grpc/channel.ex
@type t :: %__MODULE__{
        host: String.t(),          # defstruct default: nil
        port: non_neg_integer(),   # defstruct default: nil
        ...
        interceptors: [],          # real value is a non-empty list
        ...
      }
defstruct host: nil, port: nil, ...
```

`GRPC.Client.Connection.build_initial_state/2` builds the **virtual channel**
without `:host`/`:port` (they stay `nil`) and with a non-empty `:interceptors`
list — a legitimate value for a virtual / load-balanced channel, but one the type
above forbids.

`connect/2`'s success branch flows through `finalize_connection/2 → pick_channel/2`,
and `pick_channel/2` carried `@spec pick_channel(GRPC.Channel.t(), keyword())`.
Dialyzer therefore proved `pick_channel(virtual_channel, _)` could never satisfy
`GRPC.Channel.t()` (`nil ∉ String.t()`/`non_neg_integer()`, non-empty list `∉ []`),
so `finalize_connection/2` was `no_return` and `connect/2`'s success typing collapsed
to `{:error, _}`.

(v1.0.1 didn't hit this because its `connect/2` returned `{:ok, ch}` directly from
the `start_child` branch, without the `pick_channel` spec check.)

## Fix

Delete `@type t` from `GRPC.Channel` and replace the ~16 `Channel.t()` /
`GRPC.Channel.t()` references across specs and callbacks with `struct()`:

```elixir
@spec connect(String.t(), keyword()) :: {:ok, struct()} | {:error, any()}
```

`struct()` imposes no field constraints, so the over-narrow type is gone and the
false positive cannot recur — without having to keep a hand-maintained,
easily-drifting struct type in sync with `defstruct`. The now-unused
`alias GRPC.Channel` in `adapter.ex` and `load_balacing.ex` is dropped too.

## Reproduction

Any consumer matching `connect/2`'s result tripped it:

```elixir
def connect_probe do
  case GRPC.Stub.connect("localhost:50051", []) do
    {:ok, ch} -> ch          # dialyzer: pattern {:ok, _} can never match {:error, _}
    {:error, r} -> r
  end
end
```

`mix dialyzer` flagged the `{:ok, ch}` clause. With this change the warning
disappears.
