### PR TITLE
fix(client): prune a channel when its adapter connection process dies

### DIFF
--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -97,6 +97,12 @@ defmodule GRPC.Client.Connection do
       shut down, after its resources were released.
       * Measurements: none
       * Metadata: `:name`, `:target`, `:pid`, `:reason`
+    * `[:grpc, :client, :connection, :channel_pruned]` – a channel's adapter
+      connection process died and the channel was removed from the load
+      balancer, so it is no longer picked.
+      * Measurements: `:remaining` – channels still connected afterwards
+      * Metadata: `:name`, `:target`, `:pid`, `:reason`, `:address` – the
+        address key of the pruned channel
     * `[:grpc, :client, :connection, :await_ready, :start]` – a caller started
       waiting in `await_ready/2`.
       * Measurements: `:system_time`
@@ -163,6 +169,7 @@ defmodule GRPC.Client.Connection do
   @connected_event [:grpc, :client, :connection, :connected]
   @connect_error_event [:grpc, :client, :connection, :connect_error]
   @disconnected_event [:grpc, :client, :connection, :disconnected]
+  @channel_pruned_event [:grpc, :client, :connection, :channel_pruned]
   @await_ready_start_event [:grpc, :client, :connection, :await_ready, :start]
   @await_ready_stop_event [:grpc, :client, :connection, :await_ready, :stop]
 
@@ -573,20 +580,12 @@ defmodule GRPC.Client.Connection do
 
       {:noreply, state}
     else
-      Logger.warning(
-        "#{inspect(__MODULE__)} received :EXIT from #{inspect(pid)} reason: #{inspect(reason)}"
-      )
-
-      {:noreply, state}
+      {:noreply, handle_adapter_exit(pid, reason, state)}
     end
   end
 
   def handle_info({:EXIT, pid, reason}, state) do
-    Logger.warning(
-      "#{inspect(__MODULE__)} received :EXIT from #{inspect(pid)} reason: #{inspect(reason)}"
-    )
-
-    {:noreply, state}
+    {:noreply, handle_adapter_exit(pid, reason, state)}
   end
 
   def handle_info({:DOWN, mon, :process, pid, reason}, state) do
@@ -937,7 +936,7 @@ defmodule GRPC.Client.Connection do
       end
 
     if connected == [] do
-      Logger.warning("No healthy channels available after re-resolution")
+      Logger.warning("No healthy channels available")
     end
 
     %{state | real_channels: real_channels, lb_state: new_lb_state}
@@ -957,6 +956,65 @@ defmodule GRPC.Client.Connection do
 
   defp channel_alive?({:connected, _}), do: true
   defp channel_alive?(_), do: false
+
+  # An adapter connection process died. It is linked to us, so we are the only
+  # one told: the channel it backs is still `{:connected, ch}` in
+  # `real_channels` and still in the load balancer's list, so `pick_channel/2`
+  # would keep handing out a channel whose `conn_pid` is dead until the next
+  # re-resolution reconciles it. Literal-address targets (`ipv4:`, `ipv6:`,
+  # `unix:`) have no background re-resolution at all, so for those no tick is
+  # ever coming and the dead channel would be served forever.
+  defp handle_adapter_exit(pid, reason, state) do
+    case channel_key_for_conn_pid(state.real_channels, pid) do
+      nil ->
+        Logger.warning(
+          "#{inspect(__MODULE__)} received :EXIT from #{inspect(pid)} reason: #{inspect(reason)}"
+        )
+
+        state
+
+      key ->
+        Logger.warning(
+          "#{inspect(__MODULE__)} adapter connection #{inspect(pid)} exited: " <>
+            "#{inspect(reason)}, pruning its channel from the load balancer"
+        )
+
+        new_state =
+          state.real_channels
+          |> Map.put(key, {:failed, reason})
+          |> rebalance_after_reconcile(state)
+
+        :telemetry.execute(
+          @channel_pruned_event,
+          %{remaining: length(connected_channels(new_state.real_channels))},
+          state
+          |> lifecycle_metadata()
+          |> Map.merge(%{reason: reason, address: key})
+        )
+
+        maybe_reestablish(new_state)
+    end
+  end
+
+  defp channel_key_for_conn_pid(real_channels, pid) do
+    Enum.find_value(real_channels, fn
+      {key, {:connected, %{adapter_payload: %{conn_pid: ^pid}}}} -> key
+      _ -> nil
+    end)
+  end
+
+  # With channels left we simply serve them and let the next reconcile retry
+  # the failed address. With none left there is nothing to pick, so restart the
+  # establish loop from scratch -- `:retry_establish` is a no-op while
+  # `established?` is true, so that has to be cleared for the retry to run.
+  defp maybe_reestablish(state) do
+    if connected_channels(state.real_channels) == [] do
+      Process.send_after(self(), :retry_establish, backoff_delay(0))
+      %{state | established?: false, retry_attempt: 0}
+    else
+      state
+    end
+  end
 
   defp via(ref) do
     {:via, Registry, {GRPC.Client.Registry, {__MODULE__, ref}}}

--- a/grpc/test/grpc/client/connection_supervised_test.exs
+++ b/grpc/test/grpc/client/connection_supervised_test.exs
@@ -145,6 +145,96 @@ defmodule GRPC.Client.ConnectionSupervisedTest do
     end
   end
 
+  describe "adapter connection process exits" do
+    @tag capture_log: true
+    test "stops picking a channel whose adapter process died" do
+      name = unique_name("dead_channel")
+      attach_telemetry([:grpc, :client, :connection, :channel_pruned])
+
+      start_supervised!(
+        {Connection,
+         name: name,
+         target: "ipv4:127.0.0.1:50051,127.0.0.1:50052",
+         adapter: GRPC.Test.ProcessClientAdapter}
+      )
+
+      assert :ok = Connection.await_ready(name, 2_000)
+
+      assert {:ok, %GRPC.Channel{adapter_payload: %{conn_pid: dead_pid}}} =
+               Connection.pick_channel(%GRPC.Channel{ref: name})
+
+      Process.exit(dead_pid, :kill)
+
+      # The exit signal comes from the dying process, so it is not ordered
+      # against anything this process sends. Sync on the prune itself.
+      assert_receive {:telemetry, [:grpc, :client, :connection, :channel_pruned], %{remaining: 1},
+                      %{name: ^name, reason: :killed}},
+                     1_000
+
+      refute Process.alive?(dead_pid)
+
+      assert {:ok, %GRPC.Channel{adapter_payload: %{conn_pid: live_pid}}} =
+               Connection.pick_channel(%GRPC.Channel{ref: name})
+
+      assert live_pid != dead_pid
+      assert Process.alive?(live_pid)
+    end
+
+    @tag capture_log: true
+    test "re-establishes when the last remaining channel's adapter process dies" do
+      name = unique_name("last_channel")
+      attach_telemetry([:grpc, :client, :connection, :connected])
+
+      start_supervised!(
+        {Connection,
+         name: name, target: "ipv4:127.0.0.1:50051", adapter: GRPC.Test.ProcessClientAdapter}
+      )
+
+      assert :ok = Connection.await_ready(name, 2_000)
+      assert_receive {:telemetry, [:grpc, :client, :connection, :connected], _, %{name: ^name}}
+
+      assert {:ok, %GRPC.Channel{adapter_payload: %{conn_pid: dead_pid}}} =
+               Connection.pick_channel(%GRPC.Channel{ref: name})
+
+      Process.exit(dead_pid, :kill)
+
+      # The only channel is gone, so the establish loop has to run again. A
+      # second :connected event can only come from that.
+      assert_receive {:telemetry, [:grpc, :client, :connection, :connected], _, %{name: ^name}},
+                     2_000
+
+      assert {:ok, %GRPC.Channel{adapter_payload: %{conn_pid: live_pid}}} =
+               Connection.pick_channel(%GRPC.Channel{ref: name})
+
+      assert live_pid != dead_pid
+      assert Process.alive?(live_pid)
+    end
+
+    @tag capture_log: true
+    test "an unrelated linked exit leaves the channels alone" do
+      name = unique_name("unrelated_exit")
+
+      start_supervised!(
+        {Connection,
+         name: name, target: "ipv4:127.0.0.1:50051", adapter: GRPC.Test.ProcessClientAdapter}
+      )
+
+      assert :ok = Connection.await_ready(name, 2_000)
+
+      assert {:ok, %GRPC.Channel{adapter_payload: %{conn_pid: pid}}} =
+               Connection.pick_channel(%GRPC.Channel{ref: name})
+
+      conn = whereis_connection(name)
+      send(conn, {:EXIT, spawn(fn -> :ok end), :some_crash})
+      :sys.get_state(conn)
+
+      assert {:ok, %GRPC.Channel{adapter_payload: %{conn_pid: ^pid}}} =
+               Connection.pick_channel(%GRPC.Channel{ref: name})
+
+      assert Process.alive?(pid)
+    end
+  end
+
   describe "await_ready/2 waiter lifecycle" do
     setup do
       %{

--- a/grpc/test/support/test_adapter.exs
+++ b/grpc/test/support/test_adapter.exs
@@ -11,6 +11,43 @@ defmodule GRPC.Test.ClientAdapter do
   def cancel(stream), do: stream
 end
 
+defmodule GRPC.Test.ProcessClientAdapter do
+  @moduledoc """
+  A test adapter that backs each channel with a real linked process recorded
+  as `conn_pid`, the way the Gun and Mint adapters do.
+
+  `GRPC.Test.ClientAdapter` returns the channel untouched, so its channels have
+  no `conn_pid` and there is no process to kill. This adapter exists so tests
+  can kill the process behind a channel and assert on what the connection does
+  about it.
+  """
+  @behaviour GRPC.Client.Adapter
+
+  def connect(channel, _opts) do
+    {:ok, %{channel | adapter_payload: %{conn_pid: spawn_link(&idle/0)}}}
+  end
+
+  def disconnect(%{adapter_payload: %{conn_pid: pid}} = channel) when is_pid(pid) do
+    send(pid, :stop)
+    {:ok, %{channel | adapter_payload: %{conn_pid: nil}}}
+  end
+
+  def disconnect(channel), do: {:ok, channel}
+
+  defp idle do
+    receive do
+      :stop -> :ok
+    end
+  end
+
+  def send_request(stream, _message, _opts), do: stream
+  def receive_data(_stream, _opts), do: {:ok, nil}
+  def send_data(stream, _message, _opts), do: stream
+  def send_headers(stream, _opts), do: stream
+  def end_stream(stream), do: stream
+  def cancel(stream), do: stream
+end
+
 defmodule GRPC.Test.FailingClientAdapter do
   @moduledoc """
   A test adapter that refuses to connect to selected hosts. All other hosts


### PR DESCRIPTION
Fixes #569.

## Problem

Adapter connection processes are linked to `GRPC.Client.Connection`, but the `{:EXIT, …}` handler only logged a warning. The channel stayed `{:connected, ch}` in `real_channels` and stayed in the load balancer's list, so `pick_channel/2` kept handing out a channel whose `conn_pid` was dead.

Callers then fail with `:noproc` — the adapters guard only against `conn_pid: nil` (`mint.ex:84`), and a dead pid is not nil, so it falls through to `GenServer.call(dead_pid, …)`.

`lb_mod.update/2` has a single call site, reachable only from the re-resolution path, so recovery depended entirely on a resolver tick. Only `Resolver.DNS` implements the optional `init/2` that starts that timer, so for `ipv4:` / `ipv6:` / `unix:` targets no tick is ever coming and the dead channel was served for the lifetime of the connection.

## Change

In the exit handler, when the exiting pid backs one of our channels:

1. Mark that channel `{:failed, reason}`.
2. Run it through the existing `rebalance_after_reconcile/2`, so the balancer stops picking it.
3. If it was the **last** connected channel, clear `established?` and schedule `:retry_establish`.

Step 3 matters: pruning alone would swap "serves a dead channel" for "serves nothing" on literal-address targets, since nothing else would ever rebuild it. `:retry_establish` is a no-op while `established?` is true, so that flag has to be cleared for the retry to run.

Exits from pids that don't back a channel keep the previous behaviour (log and ignore) — including the resolver worker, whose gating in the clause above is untouched.

Two smaller things that follow from the change:

- Emits `[:grpc, :client, :connection, :channel_pruned]` (measurement `:remaining`, metadata adds `:reason` and `:address`), documented in the moduledoc alongside the existing events. It makes the prune observable, and it's what lets the tests synchronise without polling — the exit signal originates in the dying process, so it isn't ordered against anything the test process sends.
- `"No healthy channels available after re-resolution"` → `"No healthy channels available"`, since that branch is now reachable outside re-resolution.

## Tests

New `GRPC.Test.ProcessClientAdapter` backs each channel with a real linked process recorded as `conn_pid`, the way Gun and Mint do — `GRPC.Test.ClientAdapter` returns the channel untouched, so there was no process to kill.

Three tests in a new `"adapter connection process exits"` block:

| Test | Asserts |
| --- | --- |
| stops picking a channel whose adapter process died | two addresses, kill one → the survivor is picked, never the dead pid |
| re-establishes when the last remaining channel's adapter process dies | one address, kill it → a second `:connected` event, then a live pid |
| an unrelated linked exit leaves the channels alone | a stray `{:EXIT, …}` prunes nothing |

The first two fail on `master` and pass with the change; the third passes either way and is there as a regression guard.

`mix test` in `grpc/`: 370 passed, 2 skipped. `mix format --check-formatted` clean.

## Verified end to end

Against the reproduction in #569, `ipv4:` target — before, step 3 returned the dead pid and step 5 still did after a full `resolve_interval`. After:

```
1. picked        conn_pid=#PID<0.3399.0> alive?=true
[warning] GRPC.Client.Connection adapter connection #PID<0.3399.0> exited: :killed, pruning its channel from the load balancer
[warning] No healthy channels available
2. killed it.    alive?=false
3. picked again  conn_pid=#PID<0.3401.0> alive?=true (same? false)
4. waiting 35s for a resolver tick...
5. after tick    conn_pid=#PID<0.3401.0> alive?=true (still dead pid? false)
```

The `dns://` target recovers the same way, now in ~100ms rather than up to 30s.

## Not addressed here

When several addresses are connected and one dies, the failed address is pruned but not re-dialled until the next reconcile — so on a literal-address target it stays out. That felt like a separate change (it needs per-address retry state), and the current behaviour is still strictly better than serving a dead channel. Happy to fold it in if you'd rather.

This also doesn't touch the missing failure-feedback callback on `GRPC.Client.LoadBalancing`, which is the deeper gap described in #569 — that's a design call for you rather than something to slip into a bug fix.
