### PR TITLE
fix(client): pass dns:// hostname to Mint for TLS SNI and verification

### DIFF
--- a/grpc/lib/grpc/channel.ex
+++ b/grpc/lib/grpc/channel.ex
@@ -8,6 +8,9 @@ defmodule GRPC.Channel do
   ## Fields
 
     * `:host` - server's host to connect
+    * `:hostname` - the name the target resolved from, when `host` is an
+      address the resolver picked (e.g. a `dns://` target that resolved to an
+      IP). Used for TLS SNI and certificate hostname verification.
     * `:port` - server's port to connect
     * `:scheme` - scheme of connection, like `http`
     * `:cred` - credentials used for authentication
@@ -17,6 +20,7 @@ defmodule GRPC.Channel do
   """
 
   defstruct host: nil,
+            hostname: nil,
             port: nil,
             scheme: nil,
             cred: nil,

--- a/grpc/lib/grpc/client/adapters/mint.ex
+++ b/grpc/lib/grpc/client/adapters/mint.ex
@@ -53,6 +53,12 @@ if Code.ensure_loaded?(Mint.HTTP) do
         |> merge_opts(module_opts)
         |> Keyword.put(:retry, retry)
 
+      # A dns:// target resolves to an address (the host we dial) while the
+      # hostname it resolved from must still reach TLS for SNI and certificate
+      # verification.
+      opts =
+        if hostname = channel.hostname, do: Keyword.put(opts, :hostname, hostname), else: opts
+
       Process.flag(:trap_exit, true)
 
       channel

--- a/grpc/lib/grpc/client/connection.ex
+++ b/grpc/lib/grpc/client/connection.ex
@@ -882,7 +882,8 @@ defmodule GRPC.Client.Connection do
   end
 
   defp connect_new_channels(new_addresses, added, adapter, opts, state, real_channels) do
-    Enum.reduce(new_addresses, real_channels, fn %{address: host, port: port}, channels ->
+    Enum.reduce(new_addresses, real_channels, fn %{address: host, port: port} = address,
+                                                 channels ->
       key = build_address_key(host, port)
       existing = Map.get(channels, key)
 
@@ -897,7 +898,14 @@ defmodule GRPC.Client.Connection do
           _ -> :ok
         end
 
-        case connect_real_channel(state.virtual_channel, host, port, opts, adapter) do
+        case connect_real_channel(
+               state.virtual_channel,
+               host,
+               port,
+               opts,
+               adapter,
+               address[:hostname]
+             ) do
           {:ok, ch} -> Map.put(channels, key, {:connected, ch})
           {:error, reason} -> Map.put(channels, key, {:failed, reason})
         end
@@ -1056,8 +1064,15 @@ defmodule GRPC.Client.Connection do
   end
 
   defp build_real_channels(addresses, %Channel{} = virtual_channel, norm_opts, adapter) do
-    Map.new(addresses, fn %{port: port, address: host} ->
-      case connect_real_channel(virtual_channel, host, port, norm_opts, adapter) do
+    Map.new(addresses, fn %{port: port, address: host} = address ->
+      case connect_real_channel(
+             virtual_channel,
+             host,
+             port,
+             norm_opts,
+             adapter,
+             address[:hostname]
+           ) do
         {:ok, ch} ->
           {build_address_key(host, port), {:connected, ch}}
 
@@ -1112,8 +1127,8 @@ defmodule GRPC.Client.Connection do
   defp choose_lb(:round_robin), do: GRPC.Client.LoadBalancing.RoundRobin
   defp choose_lb(_), do: GRPC.Client.LoadBalancing.PickFirst
 
-  defp connect_real_channel(%Channel{} = vc, host, port, opts, adapter) do
-    %Channel{vc | host: host, port: port}
+  defp connect_real_channel(%Channel{} = vc, host, port, opts, adapter, hostname) do
+    %Channel{vc | host: host, port: port, hostname: hostname}
     |> adapter.connect(opts[:adapter_opts])
   end
 

--- a/grpc/lib/grpc/client/resolver/dns.ex
+++ b/grpc/lib/grpc/client/resolver/dns.ex
@@ -21,7 +21,7 @@ defmodule GRPC.Client.Resolver.DNS do
     with {:ok, addresses} <- lookup_addresses(host) do
       addrs =
         Enum.map(addresses, fn ip ->
-          %{address: :inet.ntoa(ip) |> to_string(), port: port}
+          %{address: :inet.ntoa(ip) |> to_string(), port: port, hostname: host}
         end)
 
       case lookup_service_config(host) do

--- a/grpc/test/grpc/adapters/mint_test.exs
+++ b/grpc/test/grpc/adapters/mint_test.exs
@@ -3,6 +3,11 @@ defmodule GRPC.Client.Adapters.MintTest do
 
   alias GRPC.Client.Adapters.Mint
 
+  defmodule TLSEndpoint do
+    use GRPC.Endpoint
+    run(FeatureServer)
+  end
+
   setup do
     {:ok, _, port} = GRPC.Server.start(FeatureServer, 0)
 
@@ -248,6 +253,36 @@ defmodule GRPC.Client.Adapters.MintTest do
       state = :sys.get_state(connected.adapter_payload.conn_pid)
 
       assert state.retry == 0
+    end
+  end
+
+  describe "connect/2 with hostname" do
+    setup do
+      server_credential = build(:credential)
+
+      {:ok, _, port} =
+        GRPC.Server.start_endpoint(TLSEndpoint, 0, adapter_opts: [cred: server_credential])
+
+      on_exit(fn -> :ok = GRPC.Server.stop_endpoint(TLSEndpoint) end)
+
+      %{port: port}
+    end
+
+    test "dials the resolved address but hands the hostname to Mint for TLS", %{port: port} do
+      channel =
+        build(:channel,
+          adapter: Mint,
+          port: port,
+          host: "127.0.0.1",
+          hostname: "my-service.local",
+          scheme: "https"
+        )
+
+      {:ok, connected} = Mint.connect(channel, [])
+      state = :sys.get_state(connected.adapter_payload.conn_pid)
+
+      assert state.host == "127.0.0.1"
+      assert state.connect_opts[:hostname] == "my-service.local"
     end
   end
 end

--- a/grpc/test/grpc/client/connection_test.exs
+++ b/grpc/test/grpc/client/connection_test.exs
@@ -34,6 +34,18 @@ defmodule GRPC.Client.ConnectionTest do
     end
   end
 
+  # Mirrors what GRPC.Client.Resolver.DNS returns for a dns:// target after
+  # the hostname fix: each resolved address keeps the target's hostname.
+  defmodule HostnameResolver do
+    def resolve(_target) do
+      {:ok,
+       %{
+         addresses: [%{address: "127.0.0.1", port: 50051, hostname: "my-service.local"}],
+         service_config: %{}
+       }}
+    end
+  end
+
   setup do
     %{
       ref: make_ref(),
@@ -349,6 +361,24 @@ defmodule GRPC.Client.ConnectionTest do
 
       assert_receive :interceptor_init
       refute_received :interceptor_init
+
+      Connection.disconnect(channel)
+    end
+  end
+
+  describe "connect/2 - hostname from the resolver" do
+    test "carries the dns:// hostname onto the channel for TLS SNI", %{ref: ref} do
+      resolver = HostnameResolver
+
+      {:ok, channel} =
+        Connection.connect("dns://my-service.local:50051",
+          adapter: GRPC.Test.ClientAdapter,
+          name: ref,
+          resolver: resolver
+        )
+
+      assert channel.host == "127.0.0.1"
+      assert channel.hostname == "my-service.local"
 
       Connection.disconnect(channel)
     end

--- a/grpc/test/grpc/resolver/dns_test.exs
+++ b/grpc/test/grpc/resolver/dns_test.exs
@@ -154,4 +154,20 @@ defmodule GRPC.Client.Resolver.DNSTest do
     assert [%{address: "127.0.0.1", port: 50051}] = addrs
     assert {:ok, %{load_balancing_policy: :pick_first}} = config
   end
+
+  test "keeps the hostname of a dns:// target alongside the resolved IP" do
+    host = "my-service.local"
+    config_name = "_grpc_config." <> host
+
+    DNS.MockAdapter
+    |> expect(:lookup, fn ^host, :a ->
+      {:ok, [{127, 0, 0, 1}]}
+    end)
+    |> expect(:lookup, fn ^config_name, :txt ->
+      {:ok, []}
+    end)
+
+    assert {:ok, %{addresses: addrs}} = DNS.resolve("dns://#{host}:50051")
+    assert [%{address: "127.0.0.1", port: 50051, hostname: ^host}] = addrs
+  end
 end


### PR DESCRIPTION
## Summary

A `dns://` target resolves the hostname to an IP and then dials that IP, so TLS
sees the IP where the hostname belongs: SNI carries the IP, certificate hostname
verification fails (`hostname_check_failed`, requested IP vs `*.googleapis.com`
SANs), and the `:authority` pseudo-header is wrong too.

## Root cause

`GRPC.Client.Resolver.DNS` resolves `dns://host:port` into
`%{address: ip, port: port}` and the hostname is dropped right there. The
resolved IP becomes `channel.host`, and the Mint adapter passes it to
`Mint.HTTP.connect/4`, which uses the connect host for SNI, certificate
hostname verification, and `:authority`.

## Fix

Keep the hostname alongside each resolved address, carry it onto the channel as
`hostname`, and pass it to Mint through its `:hostname` option, which is
documented for exactly this case: dial the address, but use the given hostname
for the `Host` header, hostname verification, and SNI.

Verified end to end against the real path: a `dns://` target resolving to
`127.0.0.1` now reaches `Mint.HTTP.connect(:https, "127.0.0.1", port, hostname:
"my-service.local")`.

Fixes #572

## Test plan

- `test "keeps the hostname of a dns:// target alongside the resolved IP"`: resolver-level regression test (fails on master: the address map has no
  `:hostname` key)
- `test "carries the dns:// hostname onto the channel for TLS SNI"`: the
  connection layer threads the resolver's hostname onto the channel (fails on
  master with a `KeyError` on `channel.hostname`)
- `test "dials the resolved address but hands the hostname to Mint for TLS"`: the Mint adapter hands the hostname to the connection process connect opts
  while still dialing the resolved IP (fails on master:
  `state.connect_opts[:hostname]` is `nil`)

Full suite locally: `mix test` passes except one pre-existing timing-sensitive
`ReResolveTest` flake, which reproduces on master with the same frequency
(reproduced across multiple runs on both trees).

## Notes

The Gun adapter derives SNI from the host it dials as well (gun's
`ensure_tls_opts/3` uses `origin_host`), so it has the same shape of problem
for `dns://` targets. I left it out of this PR to keep the change scoped to the
adapter from the report; passing `server_name_indication` through
`transport_opts` there would follow the same idea.
