### PR TITLE
fix: avoid binary-copy overhead when reassembling gRPC message bodies

### DIFF
--- a/grpc/lib/grpc/client/adapters/gun.ex
+++ b/grpc/lib/grpc/client/adapters/gun.ex
@@ -358,16 +358,17 @@ if Code.ensure_loaded?(:gun) do
     end
 
     defp recv_body(stream_payload, opts) do
-      recv_body(stream_payload, "", opts)
+      recv_body(stream_payload, [], opts)
     end
 
     defp recv_body(stream_payload, acc, opts) do
       case recv_data_or_trailers(stream_payload, opts) do
         {:data, data} ->
-          recv_body(stream_payload, <<acc::binary, data::binary>>, opts)
+          recv_body(stream_payload, [data | acc], opts)
 
         {:trailers, trailers} ->
-          {:ok, acc, GRPC.Transport.HTTP2.decode_headers(trailers)}
+          body = acc |> Enum.reverse() |> IO.iodata_to_binary()
+          {:ok, body, GRPC.Transport.HTTP2.decode_headers(trailers)}
 
         err ->
           err

--- a/grpc_server/lib/grpc/server/adapters/cowboy/handler.ex
+++ b/grpc_server/lib/grpc/server/adapters/cowboy/handler.ex
@@ -303,7 +303,7 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
   # APIs end
 
   def info({:read_full_body, ref, pid}, req, state) do
-    {s, body, req} = read_full_body(req, <<>>, state[:handling_timer], state.max_body_size)
+    {s, body, req} = read_full_body(req, [], 0, state[:handling_timer], state.max_body_size)
     send(pid, {ref, {s, body}})
     {:ok, req, state}
   catch
@@ -585,26 +585,26 @@ defmodule GRPC.Server.Adapters.Cowboy.Handler do
     end
   end
 
-  defp read_full_body(req, body, timer, max_bytes) do
+  defp read_full_body(req, chunks, size, timer, max_bytes) do
     result = :cowboy_req.read_body(req, timeout_left_opt(timer))
 
     case result do
       {:ok, data, req} ->
-        total = body <> data
+        size = size + byte_size(data)
 
-        if byte_size(total) > max_bytes do
-          throw({:body_too_large, byte_size(total)})
+        if size > max_bytes do
+          throw({:body_too_large, size})
         else
-          {:ok, total, req}
+          {:ok, [data | chunks] |> Enum.reverse() |> IO.iodata_to_binary(), req}
         end
 
       {:more, data, req} ->
-        total = body <> data
+        size = size + byte_size(data)
 
-        if byte_size(total) > max_bytes do
-          throw({:body_too_large, byte_size(total)})
+        if size > max_bytes do
+          throw({:body_too_large, size})
         else
-          read_full_body(req, total, timer, max_bytes)
+          read_full_body(req, [data | chunks], size, timer, max_bytes)
         end
     end
   end

--- a/grpc_server/test/grpc/server/adapters/cowboy/handler_test.exs
+++ b/grpc_server/test/grpc/server/adapters/cowboy/handler_test.exs
@@ -235,18 +235,26 @@ defmodule GRPC.Server.Adapters.Cowboy.HandlerTest do
   # read_full_body/5 is private; :local makes trace_pattern instrument it anyway.
   defp start_tracing_read_full_body do
     Code.ensure_loaded!(GRPC.Server.Adapters.Cowboy.Handler)
-    :erlang.trace_pattern({GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, :_}, true, [:local])
+
+    :erlang.trace_pattern({GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, :_}, true, [
+      :local
+    ])
+
     :erlang.trace(:all, true, [:call])
   end
 
   defp stop_tracing_read_full_body do
     :erlang.trace(:all, false, [:call])
-    :erlang.trace_pattern({GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, :_}, false, [:local])
+
+    :erlang.trace_pattern({GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, :_}, false, [
+      :local
+    ])
   end
 
   defp await_read_full_body_call do
-    assert_receive {:trace, _pid, :call, {GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, _args}},
-                    2_000
+    assert_receive {:trace, _pid, :call,
+                    {GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, _args}},
+                   2_000
   end
 
   # --------------------------------------------------------------------------

--- a/grpc_server/test/grpc/server/adapters/cowboy/handler_test.exs
+++ b/grpc_server/test/grpc/server/adapters/cowboy/handler_test.exs
@@ -73,6 +73,39 @@ defmodule GRPC.Server.Adapters.Cowboy.HandlerTest do
     end
   end
 
+  # Like collect_grpc_status/2, but also decodes the accumulated body as a HelloReply.
+  defp collect_grpc_response(conn, stream_ref) do
+    collect_grpc_response(conn, stream_ref, nil, <<>>)
+  end
+
+  defp collect_grpc_response(conn, stream_ref, last_status, body) do
+    case :gun.await(conn, stream_ref, 5_000) do
+      {:response, :fin, _http_status, headers} ->
+        {find_grpc_status(headers) || last_status, decode_hello_reply(body)}
+
+      {:response, :nofin, _http_status, headers} ->
+        collect_grpc_response(conn, stream_ref, find_grpc_status(headers), body)
+
+      {:data, :fin, data} ->
+        {last_status, decode_hello_reply(body <> data)}
+
+      {:data, :nofin, data} ->
+        collect_grpc_response(conn, stream_ref, last_status, body <> data)
+
+      {:trailers, trailers} ->
+        {find_grpc_status(trailers) || last_status, decode_hello_reply(body)}
+
+      {:error, reason} ->
+        flunk("gun error: #{inspect(reason)}")
+    end
+  end
+
+  defp decode_hello_reply(<<_flag::8, length::32, message::bytes-size(length), _rest::binary>>) do
+    Protobuf.decode(message, Helloworld.HelloReply)
+  end
+
+  defp decode_hello_reply(_incomplete), do: nil
+
   # --------------------------------------------------------------------------
   # Tests: max_body_size enforcement
   # --------------------------------------------------------------------------
@@ -153,6 +186,67 @@ defmodule GRPC.Server.Adapters.Cowboy.HandlerTest do
         :gun.close(conn)
       end)
     end
+  end
+
+  # --------------------------------------------------------------------------
+  # Tests: request body delivered across multiple HTTP/2 DATA frames
+  # --------------------------------------------------------------------------
+
+  describe "streamed request body" do
+    # read_full_body/5 recurses once per :more read; every other test in this
+    # file sends a body small enough to complete in a single :ok read, so
+    # this is the only test that exercises that recursive accumulation path.
+    test "reassembles a request body sent as several separate DATA frames, in order" do
+      run_server_with_opts([HelloServer], [], fn port ->
+        # Distinct segments so a dropped, duplicated, or reordered chunk changes the decoded name.
+        chunk_a = String.duplicate("a", 20_000)
+        chunk_b = String.duplicate("b", 20_000)
+        chunk_c = String.duplicate("c", 20_000)
+        name = chunk_a <> chunk_b <> chunk_c
+
+        body = grpc_frame(Protobuf.encode(%Helloworld.HelloRequest{name: name}))
+        <<part1::bytes-size(20_005), part2::bytes-size(20_000), part3::binary>> = body
+
+        conn = open_h2(port)
+
+        start_tracing_read_full_body()
+
+        stream_ref =
+          :gun.headers(conn, "POST", "/helloworld.Greeter/SayHello", grpc_request_headers())
+
+        # Waiting for read_full_body to recurse before each send proves the
+        # chunk just sent already landed in its own read_body call.
+        await_read_full_body_call()
+        :gun.data(conn, stream_ref, :nofin, part1)
+        await_read_full_body_call()
+        :gun.data(conn, stream_ref, :nofin, part2)
+        await_read_full_body_call()
+        :gun.data(conn, stream_ref, :fin, part3)
+
+        assert {"0", reply} = collect_grpc_response(conn, stream_ref)
+        assert reply.message == "Hello, #{name}"
+
+        stop_tracing_read_full_body()
+        :gun.close(conn)
+      end)
+    end
+  end
+
+  # read_full_body/5 is private; :local makes trace_pattern instrument it anyway.
+  defp start_tracing_read_full_body do
+    Code.ensure_loaded!(GRPC.Server.Adapters.Cowboy.Handler)
+    :erlang.trace_pattern({GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, :_}, true, [:local])
+    :erlang.trace(:all, true, [:call])
+  end
+
+  defp stop_tracing_read_full_body do
+    :erlang.trace(:all, false, [:call])
+    :erlang.trace_pattern({GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, :_}, false, [:local])
+  end
+
+  defp await_read_full_body_call do
+    assert_receive {:trace, _pid, :call, {GRPC.Server.Adapters.Cowboy.Handler, :read_full_body, _args}},
+                    2_000
   end
 
   # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`recv_body` (gun client adapter) and `read_full_body` (cowboy server handler) both
reassembled incoming message bodies by rebuilding the accumulated binary on every
chunk:

```elixir
recv_body(stream_payload, <<acc::binary, data::binary>>, opts)
```

BEAM
[optimizes single-reference binary appends in place](https://www.erlang.org/doc/system/binaryhandling.html#constructing-binaries)
rather than always copying, so this isn't unbounded quadratic growth. Even so, it
measured consistently several times slower than an iolist accumulator across realistic
body sizes, with peak memory modestly above the final size (benchmark details below).
The iolist approach is both faster and doesn't depend on a runtime heuristic that other
code nearby (message sends, ETS inserts, pattern matches on the accumulator) could
invalidate.

## Fix

Both functions now accumulate chunks as a list and flatten once via
`IO.iodata_to_binary/1`, giving `O(n)` time and allocation independent of the
append-in-place heuristic.

## Testing

Added a regression test for the server-side recursive `:more` path in
`read_full_body/5`. It previously had zero coverage, since every other existing test
sends a body small enough to complete in a single `:cowboy_req.read_body` call. The
new test forces the body across multiple separate reads, pacing each send by tracing
`read_full_body`'s recursion so the multi-chunk path is provably exercised on every
run rather than assumed.

<details>
<summary>Benchmark methodology and results</summary>

Benchmarked on both Elixir 1.15.4/OTP 26 and Elixir 1.20.3/OTP 28, timing a body built
from 16KB chunks (HTTP/2's default max frame size, and what this project's gun/cowboy
stack actually negotiates). Median of 10 runs each, isolated in a fresh process per run:

| Body size | OLD | NEW | ratio |
|---|---|---|---|
| 4 MB | 2.5 ms | 0.2 ms | 12.5x |
| 8 MB | 4.7 ms | 0.5 ms | 9.4x |
| 16 MB | 9.0 ms | 1.3 ms | 6.9x |
| 32 MB | 17.9 ms | 2.4 ms | 7.5x |
| 64 MB | 34.9 ms | 4.9 ms | 7.1x |
| 128 MB | 66.8 ms | 9.5 ms | 7.0x |

These are medians; individual runs varied more (up to ~17x in one-off checks), since
wall-clock time is far more sensitive to scheduler noise than allocation size is.

Peak binary memory during a 128 MB reassembly: 137.6 MB for OLD vs 128.0 MB for NEW,
about 8% overhead — a full retained duplicate would show closer to 2x, so this is
modest slack, not a second copy sitting around. That figure was reproducible
bit-for-bit across 5 repeat runs.

Most real gRPC messages fit in a single HTTP/2 frame, so also checked single-chunk
bodies separately. No regression — NEW is faster there too, by a growing margin:

| Payload size | OLD | NEW | ratio |
|---|---|---|---|
| 64 B | 0.065 µs | 0.017 µs | 3.8x |
| 256 B | 0.067 µs | 0.017 µs | 3.9x |
| 1 KB | 0.073 µs | 0.017 µs | 4.3x |
| 4 KB | 0.108 µs | 0.017 µs | 6.4x |
| 16 KB | 0.279 µs | 0.017 µs | 16.4x |

For a single-chunk body, `IO.iodata_to_binary/1` returns the original chunk unchanged
instead of copying it (confirmed with `:erts_debug.same/2`). OLD always pays a real
copy here, since appending onto `<<>>` is a first-time append and can't skip it.

Chunk size (independent of total body size) also shifts the ratio: it narrows to ~3x
with very small (1KB) chunks, since NEW's list overhead scales with chunk count, and
levels off around 7-8x from 16KB up through 1MB chunks. At the extreme where the whole
body is one chunk, NEW hits the zero-copy case above and the gap widens to 1000x+.
Oddly, OLD also gets fast at exactly 2 equal-sized chunks, likely a lucky alignment
with BEAM's binary growth doubling, briefly narrowing the gap to ~1x. NEW was never
slower than OLD in any configuration tested.

Scripts: https://gist.github.com/asweet-confluent/2c1c4fefba69da34639f62f12fb0204e

</details>

*This PR was made with AI assistance.*
