### PR TITLE
fix(gun): scope named connection processes to the local node

### DIFF
--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Behavior Changes
 
   * The Mint adapter now enforces the requested `:timeout`/`:deadline` on unary receives. A unary call that never receives a response fails with `DEADLINE_EXCEEDED` after the documented 10s default instead of blocking indefinitely, and an explicit `:deadline` now takes precedence over `:timeout`.
+
+### Bug Fixes
+
+  * The Gun adapter no longer shares a named channel's connection process across Erlang nodes. It was registered in `:global`, so a node connecting with a `:name` already used on another node adopted the remote connection process; `connect/2` returned `{:ok, channel}`, but every RPC on it then raised `ArgumentError` because `GRPC.Stub.call/5` calls `Process.alive?/1` on the connection pid and that raises for remote pids. Connection processes are now registered in the node-local `GRPC.Client.Registry`, so reuse is per node.
+
 ## v1.0.4 (2026-0-15)
 
 ### Bug Fixes

--- a/grpc/lib/grpc/client/adapters/gun/connection_process.ex
+++ b/grpc/lib/grpc/client/adapters/gun/connection_process.ex
@@ -13,6 +13,9 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
   Request-specific Gun messages are routed to per-stream response processes, so
   this process only needs to manage connection-level lifecycle and stream
   bookkeeping.
+
+  Named channels are registered in the node-local `GRPC.Client.Registry` under
+  `{ref, host, port}`, so a connection is reused by every caller on the node.
   """
 
   use GenServer
@@ -177,7 +180,7 @@ defmodule GRPC.Client.Adapters.Gun.ConnectionProcess do
   end
 
   defp via(channel) do
-    {:global, {__MODULE__, owner_key(channel)}}
+    {:via, Registry, {GRPC.Client.Registry, {__MODULE__, owner_key(channel)}}}
   end
 
   defp start_response_process do

--- a/grpc/test/grpc/adapters/gun_test.exs
+++ b/grpc/test/grpc/adapters/gun_test.exs
@@ -2,6 +2,7 @@ defmodule GRPC.Client.Adapters.GunTest do
   use GRPC.Client.DataCase, async: true
 
   alias GRPC.Client.Adapters.Gun
+  alias GRPC.Client.Adapters.Gun.ConnectionProcess
 
   defmodule Endpoint do
     use GRPC.Endpoint
@@ -96,6 +97,46 @@ defmodule GRPC.Client.Adapters.GunTest do
                    ip: :loopback
                  ]
                )
+    end
+
+    test "reuses the connection process for a named channel", %{
+      port: port,
+      credential: credential
+    } do
+      channel =
+        build(:channel, port: port, host: "localhost", cred: credential, ref: make_ref())
+
+      assert {:ok, %{adapter_payload: %{conn_pid: conn_pid}} = connected} =
+               Gun.connect(channel, [])
+
+      on_exit(fn -> Gun.disconnect(connected) end)
+
+      assert {:ok, %{adapter_payload: %{conn_pid: ^conn_pid}}} = Gun.connect(channel, [])
+
+      assert [{^conn_pid, _}] =
+               Registry.lookup(
+                 GRPC.Client.Registry,
+                 {ConnectionProcess, {channel.ref, channel.host, channel.port}}
+               )
+    end
+
+    test "does not reuse the connection process for an unnamed channel", %{
+      port: port,
+      credential: credential
+    } do
+      channel = build(:channel, port: port, host: "localhost", cred: credential)
+
+      assert {:ok, %{adapter_payload: %{conn_pid: first_pid}} = first} = Gun.connect(channel, [])
+
+      assert {:ok, %{adapter_payload: %{conn_pid: second_pid}} = second} =
+               Gun.connect(channel, [])
+
+      on_exit(fn ->
+        Gun.disconnect(first)
+        Gun.disconnect(second)
+      end)
+
+      refute first_pid == second_pid
     end
   end
 

--- a/grpc/test/grpc/client/connection_test.exs
+++ b/grpc/test/grpc/client/connection_test.exs
@@ -378,11 +378,28 @@ defmodule GRPC.Client.ConnectionTest do
       target = "ipv4:127.0.0.1:#{port}"
       ref = :shared_channel
 
-      assert {:ok, %Channel{ref: ^ref}} =
+      assert {:ok, %Channel{ref: ^ref} = channel1} =
                @peer.call(peer1, Connection, :connect, [target, [name: ref]])
 
-      assert {:ok, %Channel{ref: ^ref}} =
+      assert {:ok, %Channel{ref: ^ref} = channel2} =
                @peer.call(peer2, Connection, :connect, [target, [name: ref]])
+
+      # Each node must own its own adapter connection. Adopting another node's
+      # connection process leaves the channel unusable: `GRPC.Stub.call/5`
+      # checks `Process.alive?(conn_pid)` on every RPC, and `Process.alive?/1`
+      # raises ArgumentError on a remote pid.
+      %{adapter_payload: %{conn_pid: conn_pid1}} = channel1
+      %{adapter_payload: %{conn_pid: conn_pid2}} = channel2
+
+      assert node(conn_pid1) == node1
+      assert node(conn_pid2) == node2
+
+      point = %Routeguide.Point{latitude: 409_146_138, longitude: -746_188_906}
+
+      for {peer, channel} <- [{peer1, channel1}, {peer2, channel2}] do
+        assert {:ok, %Routeguide.Feature{}} =
+                 @peer.call(peer, Routeguide.RouteGuide.Stub, :get_feature, [channel, point])
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

`GRPC.Client.Adapters.Gun.ConnectionProcess` registers itself under `{:global, {ConnectionProcess, {ref, host, port}}}` ([`connection_process.ex:180`](https://github.com/elixir-grpc/grpc/blob/master/grpc/lib/grpc/client/adapters/gun/connection_process.ex#L180)). `:global` is cluster-wide, which has two distinct consequences on a connected Erlang cluster.

**1. A node can adopt another node's connection, and the channel is then unusable.** Two nodes calling `GRPC.Stub.connect(addr, name: :foo)` collide on the same global name. The second gets `{:error, {:already_started, remote_pid}}`, which `connect/2` treats as successful reuse — so it returns `{:ok, channel}` with a `conn_pid` that lives on the other node.

Nothing is actually sent over that channel. `GRPC.Stub.call/5` checks `Process.alive?(conn_pid)` on every RPC ([`stub.ex:298`](https://github.com/elixir-grpc/grpc/blob/master/grpc/lib/grpc/stub.ex#L298)), and `Process.alive?/1` raises on a remote pid, so every call fails before a request leaves the node:

```
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a local pid

  :erlang.is_process_alive(#PID<25985.168.0>)
  (grpc 1.0.4) lib/grpc/stub.ex:298: GRPC.Stub.call/5
```

`GRPC.Client.Connection.channel_alive?/1` ([`connection.ex:939`](https://github.com/elixir-grpc/grpc/blob/master/grpc/lib/grpc/client/connection.ex#L939)) has the same problem and would raise on the next DNS re-resolve, but the hot-path check fires first. The failure mode is therefore: `connect/2` succeeds, then every RPC on that channel raises.

**2. Every connect pays a cluster-wide registration**, even when no name is ever shared. Callers that don't pass `:name` still get one — `connect/2` fills in `make_ref/0` — so `channel.ref` is non-nil and the process registers globally under a name nothing else will ever look up. `:global.register_name/3` takes a global lock and multi-calls every connected node, and `:global` then keeps that name in a table it must reconcile on every node join and leave.

## Production measurement

Deployed on an Elixir service whose pods are clustered via libcluster. Because that service uses unique per-connect names, it only ever hit consequence 2, never 1.

The measurement comes from an endpoint that should be very fast but opens a gRPC connection on every call, so it pays the connect penalty often — meaning it over-represents the connect path relative to steady-state RPC traffic.

<img width="620" height="547" alt="Screenshot 2026-08-27 at 12 48 21" src="https://github.com/user-attachments/assets/ab76f092-b21c-43d0-b212-b27356907fc3" />


Request volume flat at ~40/interval throughout. As the patched version takes over traffic, p95 goes from a spiky 100–215 ms to a flat line under ~5 ms, with p50/p75/p99 dropping together, sustained for 30+ minutes.

Traffic that reuses an established channel should see little or nothing from this change, since it doesn't touch `:global` after the initial connect.

## Fix

Register in the node-local `GRPC.Client.Registry`, which `GRPC.Client.Connection` already uses:

```elixir
{:via, Registry, {GRPC.Client.Registry, {__MODULE__, owner_key(channel)}}}
```

Reuse becomes per node, which matches the intent of #519 (keeping named channels alive after the calling process exits) — that change needed the process to outlive its caller, not to be shared across the cluster.

## Tests

- `test/grpc/adapters/gun_test.exs` — a named channel connected twice returns the same `conn_pid` and is registered in `GRPC.Client.Registry`; an unnamed channel gets a fresh process each time.
- `test/grpc/client/connection_test.exs` — the existing two-node "named channels do not conflict across connected nodes" test asserted only that both connects returned `{:ok, _}`, which held while the two nodes shared one process. Extended to assert each node's `conn_pid` is local to that node, and to issue a real RPC from each node so the unusable-channel case is covered rather than just the pid location.

Both fail on master and pass with the fix. Full suite green; `mix format --check-formatted` clean. CHANGELOG entry added under Unreleased.
