### PR TITLE
fix(mint): return raw connect errors, not strings

### DIFF
--- a/grpc/CHANGELOG.md
+++ b/grpc/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Behavior Changes
 
   * The Mint adapter now enforces the requested `:timeout`/`:deadline` on unary receives. A unary call that never receives a response fails with `DEADLINE_EXCEEDED` after the documented 10s default instead of blocking indefinitely, and an explicit `:deadline` now takes precedence over `:timeout`.
+  * `GRPC.Client.Adapters.Mint.connect/2` now returns errors directly, instead of formatting as a string.
 
 ### Bug Fixes
 

--- a/grpc/lib/grpc/client/adapters/mint.ex
+++ b/grpc/lib/grpc/client/adapters/mint.ex
@@ -59,15 +59,11 @@ if Code.ensure_loaded?(Mint.HTTP) do
       |> mint_scheme()
       |> ConnectionProcess.start_link(host, port, opts)
       |> case do
-        {:ok, pid} ->
-          {:ok, %{channel | adapter_payload: %{conn_pid: pid}}}
-
-        error ->
-          {:error, "Error while opening connection: #{inspect(error)}"}
+        {:ok, pid} -> {:ok, %{channel | adapter_payload: %{conn_pid: pid}}}
+        error -> error
       end
     catch
-      :exit, reason ->
-        {:error, "Error while opening connection: #{inspect(reason)}"}
+      :exit, reason -> {:error, reason}
     end
 
     @impl true

--- a/grpc/test/grpc/adapters/mint_test.exs
+++ b/grpc/test/grpc/adapters/mint_test.exs
@@ -28,9 +28,7 @@ defmodule GRPC.Client.Adapters.MintTest do
       assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result
 
       # Ensure that changing one of the options breaks things
-      assert {:error, message} = Mint.connect(channel, transport_opts: [ip: "256.0.0.0"])
-
-      assert message == "Error while opening connection: {:error, :badarg}"
+      assert {:error, :badarg} = Mint.connect(channel, transport_opts: [ip: "256.0.0.0"])
     end
 
     test "accepts config_options for application specific configuration", %{port: port} do
@@ -42,10 +40,8 @@ defmodule GRPC.Client.Adapters.MintTest do
       assert %{channel | adapter_payload: %{conn_pid: result.adapter_payload.conn_pid}} == result
 
       # Ensure that changing one of the options via config_options also breaks things
-      assert {:error, message} =
+      assert {:error, :badarg} =
                Mint.connect(channel, config_options: [transport_opts: [ip: "256.0.0.0"]])
-
-      assert message == "Error while opening connection: {:error, :badarg}"
     end
 
     test "defaults client settings when none is passed", %{port: port} do


### PR DESCRIPTION
# Return Mint connect failure reason, not a formatted string

Currently, `connect/2` inspects whatever `ConnectionProcess.start_link/4` returns into a message, so a refused connection results in: `{:error, "Error while opening connection: {:error, %Mint.TransportError{reason: :econnrefused}}"}`. This is hard for callers to use, e.g. in a case expression. The Gun adapter returns transport errors directly.

*Changes*
- `connect/2` and its catch :exit clause return the error tuple directly. 
